### PR TITLE
feat: singingランキング導線をランキングページに統一

### DIFF
--- a/app/views/singing/homes/top.html.haml
+++ b/app/views/singing/homes/top.html.haml
@@ -8,7 +8,7 @@
     .singing-top__actions
       = link_to "診断を始める", new_singing_diagnosis_path, class: "btn btn-primary"
       = link_to "成長記録", singing_diagnoses_path, class: "btn btn-secondary"
-      = link_to "ランキングページへ", singing_rankings_path, class: "btn btn-secondary singing-top__ranking-btn"
+      = link_to "ランキング", singing_rankings_path, class: "btn btn-secondary singing-top__ranking-btn"
       = link_to "BeMyStyleトップへ", root_path, class: "btn btn-secondary"
       = button_to "ログアウト",
         destroy_customer_session_path,

--- a/app/views/singing/rankings/index.html.haml
+++ b/app/views/singing/rankings/index.html.haml
@@ -2,10 +2,11 @@
   .singing-ranking__hero
     .singing-ranking__hero-inner
       %p.singing-ranking__eyebrow RANKING
-      %h1.singing-ranking__hero-title
-        みんなの演奏力
+      %h1.singing-ranking__hero-title ランキング
+      %p.singing-ranking__hero-intro
+        診断に参加したみんなのチャレンジ結果を確認できます。
         %br
-        ランキング
+        総合ランキングとシーズンランキングを切り替えて楽しめます。
       - case @ranking_type
       - when "growth"
         %p.singing-ranking__hero-subtitle
@@ -14,18 +15,12 @@
           挑戦し続ける全ての方を応援しています。
       - when "season"
         %p.singing-ranking__hero-subtitle
-          - if @current_season
-            = @current_season.name
-            &mdash;
-          = @season_range.begin.strftime("%Y年%-m月")
-          のランキングです。
+          今月の診断結果をもとにした期間限定ランキングです。
           %br
-          毎月リセットされるので、何度でも挑戦できます。
+          毎月リセットされるため、誰でも上位を目指しやすいランキングです。
       - else
         %p.singing-ranking__hero-subtitle
-          歌唱・演奏診断を受けたユーザーの中から、
-          %br
-          ランキング参加者のベストスコアを公開しています。
+          これまでの診断結果の中で、各ユーザーの最高スコアをもとにしたランキングです。
 
   .singing-ranking__inner
     - case @ranking_type

--- a/app/views/singing/shared/_header.html.haml
+++ b/app/views/singing/shared/_header.html.haml
@@ -8,10 +8,6 @@
       = link_to "診断トップ", singing_root_path, class: "singing-nav__link#{' singing-nav__link--active' if current_page?(singing_root_path)}"
       = link_to "診断する", new_singing_diagnosis_path, class: "singing-nav__link#{' singing-nav__link--active' if current_page?(new_singing_diagnosis_path)}"
       = link_to "成長記録", singing_diagnoses_path, class: "singing-nav__link#{' singing-nav__link--active' if current_page?(singing_diagnoses_path)}"
-      = link_to singing_ranking_seasons_path, class: "singing-nav__link singing-nav__link--season#{' singing-nav__link--active' if request.path.start_with?(singing_ranking_seasons_path)}" do
-        シーズン
-        - if SingingRankingSeason.current.exists?
-          %span.singing-nav__season-dot
       - if current_customer
         = link_to "プロフィール", singing_user_path(current_customer), class: "singing-nav__link#{' singing-nav__link--active' if current_page?(singing_user_path(current_customer))}"
         = link_to singing_notifications_path, class: "singing-nav__link singing-nav__link--with-badge#{' singing-nav__link--active' if current_page?(singing_notifications_path)}" do
@@ -66,10 +62,6 @@
         = link_to "診断トップ", singing_root_path, class: "singing-nav__mobile-link"
         = link_to "診断する", new_singing_diagnosis_path, class: "singing-nav__mobile-link singing-nav__mobile-link--primary"
         = link_to "成長記録", singing_diagnoses_path, class: "singing-nav__mobile-link"
-        = link_to singing_ranking_seasons_path, class: "singing-nav__mobile-link" do
-          シーズンランキング
-          - if SingingRankingSeason.current.exists?
-            %span.singing-nav__badge-inline 開催中
         - if current_customer
           = link_to "プロフィール", singing_user_path(current_customer), class: "singing-nav__mobile-link"
           = link_to singing_notifications_path, class: "singing-nav__mobile-link" do
@@ -77,7 +69,7 @@
             - unchecked_count = current_customer.passive_notifications.where(checked: false).count
             - if unchecked_count.positive?
               %span.singing-nav__badge= unchecked_count
-        = link_to "ランキングページへ", singing_rankings_path, class: "singing-nav__mobile-link singing-nav__mobile-link--cta"
+        = link_to "ランキング", singing_rankings_path, class: "singing-nav__mobile-link singing-nav__mobile-link--cta"
         = link_to "BeMyStyleへ", root_path, class: "singing-nav__mobile-link singing-nav__mobile-link--cta"
         = link_to "料金プラン", public_singing_lp_path(anchor: "lp-section"), class: "singing-nav__mobile-link"
         - if current_customer

--- a/spec/requests/singing/rankings_spec.rb
+++ b/spec/requests/singing/rankings_spec.rb
@@ -535,9 +535,9 @@ RSpec.describe "Singing::Rankings", type: :request do
       end
 
       context "共通ナビ" do
-        it "シーズンランキングへのリンクを含むこと" do
+        it "ランキングへのリンクを含むこと" do
           get singing_rankings_path
-          expect(response.body).to include(singing_ranking_seasons_path)
+          expect(response.body).to include(singing_rankings_path)
         end
       end
     end


### PR DESCRIPTION
- ヘッダー desktop nav の「シーズン」リンク（ranking_seasons_path）を削除
- ヘッダー mobile menu の「シーズンランキング」リンクを削除
- モバイルの「ランキングページへ」→「ランキング」に文言統一
- 診断トップの「ランキングページへ」→「ランキング」に文言統一
- ランキング hero に全タブ共通の紹介文を追加
- 各タブのサブタイトルを要件通りの説明文に更新
- spec のナビリンクテストを新しい設計に合わせて更新