### PR TITLE
feat: シーズンバッジ表示UIを追加

### DIFF
--- a/app/assets/stylesheets/singing/diagnoses.scss
+++ b/app/assets/stylesheets/singing/diagnoses.scss
@@ -5803,3 +5803,150 @@ $ranking-accent: #7c4dff;
   padding: 2px 7px;
   vertical-align: middle;
 }
+
+// ─── シーズンバッジ（診断結果画面）───────────────────────────────────
+@keyframes singing-badge-new-pulse {
+  0%, 100% { box-shadow: 0 0 0 0 rgba(255, 200, 0, 0.4); }
+  50%       { box-shadow: 0 0 0 6px rgba(255, 200, 0, 0); }
+}
+
+.singing-diagnosis__season-badges {
+  margin: 32px 0;
+  padding: 24px;
+  background: linear-gradient(135deg, #fffbea 0%, #fff8e1 100%);
+  border: 1px solid #f5c842;
+  border-radius: 12px;
+
+  h2 {
+    font-size: 18px;
+    font-weight: 700;
+    margin: 0 0 4px;
+  }
+}
+
+.singing-diagnosis__season-badges-lead {
+  font-size: 13px;
+  color: #777;
+  margin: 0 0 16px;
+}
+
+.singing-diagnosis__season-badge-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.singing-diagnosis__season-badge {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  background: #fff;
+  border: 1px solid #e8d88a;
+  border-radius: 8px;
+  padding: 10px 14px;
+  position: relative;
+
+  &--new {
+    animation: singing-badge-new-pulse 1.6s ease-in-out 3;
+    border-color: #f5c842;
+  }
+}
+
+.singing-diagnosis__season-badge-emoji {
+  font-size: 28px;
+  line-height: 1;
+}
+
+.singing-diagnosis__season-badge-body {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.singing-diagnosis__season-badge-label {
+  font-size: 14px;
+  font-weight: 700;
+  color: #2c2c2c;
+}
+
+.singing-diagnosis__season-badge-season {
+  font-size: 11px;
+  color: #888;
+}
+
+.singing-diagnosis__season-badge-new {
+  position: absolute;
+  top: -8px;
+  right: -8px;
+  background: #f5c842;
+  color: #2c2c2c;
+  font-size: 9px;
+  font-weight: 800;
+  padding: 2px 5px;
+  border-radius: 4px;
+  letter-spacing: 0.05em;
+}
+
+// ─── シーズンバッジ（プロフィール画面）──────────────────────────────
+.singing-profile__season-badge-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.singing-profile__season-badge-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  background: #fff;
+  border: 1px solid #e8e8e8;
+  border-radius: 8px;
+  padding: 10px 14px;
+  position: relative;
+
+  &--new {
+    border-color: #f5c842;
+    animation: singing-badge-new-pulse 1.6s ease-in-out 3;
+  }
+}
+
+.singing-profile__season-badge-emoji {
+  font-size: 28px;
+  line-height: 1;
+  flex-shrink: 0;
+}
+
+.singing-profile__season-badge-body {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.singing-profile__season-badge-label {
+  font-size: 14px;
+  font-weight: 700;
+  color: #2c2c2c;
+}
+
+.singing-profile__season-badge-season {
+  font-size: 12px;
+  color: #888;
+}
+
+.singing-profile__season-badge-new {
+  margin-left: auto;
+  background: #f5c842;
+  color: #2c2c2c;
+  font-size: 9px;
+  font-weight: 800;
+  padding: 2px 6px;
+  border-radius: 4px;
+  letter-spacing: 0.05em;
+  flex-shrink: 0;
+}
+
+.singing-profile__season-badge-more {
+  font-size: 13px;
+  color: #777;
+  margin-top: 8px;
+}

--- a/app/controllers/singing/diagnoses_controller.rb
+++ b/app/controllers/singing/diagnoses_controller.rb
@@ -35,7 +35,10 @@ class Singing::DiagnosesController < Singing::BaseController
 
   def show
     @polling_required = @diagnosis.queued? || @diagnosis.processing?
-    @growth_diagnoses = growth_diagnoses_for(@diagnosis) if @diagnosis.completed?
+    if @diagnosis.completed?
+      @growth_diagnoses = growth_diagnoses_for(@diagnosis)
+      @diagnosis_season_badges = latest_season_badges_for(current_customer)
+    end
   end
 
   private
@@ -86,5 +89,15 @@ class Singing::DiagnosesController < Singing::BaseController
       .limit(8)
       .to_a
       .reverse
+  end
+
+  def latest_season_badges_for(customer)
+    latest_season = SingingRankingSeason.closed.order(ends_on: :desc).first
+    return [] unless latest_season
+
+    customer.singing_badges
+            .includes(:singing_ranking_season)
+            .where(singing_ranking_season: latest_season)
+            .order(awarded_at: :desc)
   end
 end

--- a/app/controllers/singing/users_controller.rb
+++ b/app/controllers/singing/users_controller.rb
@@ -14,6 +14,9 @@ class Singing::UsersController < Singing::BaseController
     @ranking_position = Singing::RankingQuery.position_for(@user.id)
     @season_position = Singing::RankingQuery.season_position_for(@user.id)
     @season_achievement_entries = season_achievement_entries
+    @season_badges = @user.singing_badges
+                          .includes(:singing_ranking_season)
+                          .order(awarded_at: :desc)
     @ranking_badges = Singing::RankingBadgeService.badges_for(@user)
     @growth_entries = Singing::RankingQuery.growth
     @growth_index = @growth_entries.index { |entry| entry.customer.id == @user.id }

--- a/app/helpers/singing/badges_helper.rb
+++ b/app/helpers/singing/badges_helper.rb
@@ -1,0 +1,25 @@
+module Singing
+  module BadgesHelper
+    NEW_BADGE_THRESHOLD = 7.days
+
+    def singing_badge_label(badge)
+      badge.label
+    end
+
+    def singing_badge_emoji(badge)
+      badge.emoji
+    end
+
+    def singing_badge_display_text(badge)
+      badge.display_text
+    end
+
+    def singing_badge_season_name(badge)
+      badge.singing_ranking_season&.name
+    end
+
+    def singing_badge_new?(badge)
+      badge.awarded_at >= NEW_BADGE_THRESHOLD.ago
+    end
+  end
+end

--- a/app/views/singing/diagnoses/show.html.haml
+++ b/app/views/singing/diagnoses/show.html.haml
@@ -85,6 +85,20 @@
               %small= card[:short_label]
               %p= card[:comment]
 
+      - if @diagnosis_season_badges.present?
+        .singing-diagnosis__season-badges
+          %h2 今回のあなたの実績
+          %p.singing-diagnosis__season-badges-lead 直近シーズンで獲得したバッジです。
+          .singing-diagnosis__season-badge-list
+            - @diagnosis_season_badges.each do |badge|
+              .singing-diagnosis__season-badge{ class: (singing_badge_new?(badge) ? "singing-diagnosis__season-badge--new" : "") }
+                %span.singing-diagnosis__season-badge-emoji= singing_badge_emoji(badge)
+                .singing-diagnosis__season-badge-body
+                  %strong.singing-diagnosis__season-badge-label= singing_badge_label(badge)
+                  %small.singing-diagnosis__season-badge-season= singing_badge_season_name(badge)
+                - if singing_badge_new?(badge)
+                  %span.singing-diagnosis__season-badge-new NEW
+
       .singing-diagnosis__score-guides
         %h2 スコアの見方
         %p.singing-diagnosis__score-note この診断は現時点の音声から見た目安です。絶対的な評価ではなく、練習や振り返りのヒントとしてご活用ください。

--- a/app/views/singing/users/show.html.haml
+++ b/app/views/singing/users/show.html.haml
@@ -96,6 +96,26 @@
 
       %section.singing-profile__section
         .singing-profile__section-head
+          %p.singing-profile__section-kicker Badges
+          %h2 シーズンバッジ
+        - if @season_badges.any?
+          .singing-profile__season-badge-list
+            - @season_badges.first(6).each do |badge|
+              .singing-profile__season-badge-item{ class: (singing_badge_new?(badge) ? "singing-profile__season-badge-item--new" : "") }
+                %span.singing-profile__season-badge-emoji= singing_badge_emoji(badge)
+                .singing-profile__season-badge-body
+                  %strong.singing-profile__season-badge-label= singing_badge_label(badge)
+                  %small.singing-profile__season-badge-season= singing_badge_season_name(badge)
+                - if singing_badge_new?(badge)
+                  %span.singing-profile__season-badge-new NEW
+          - if @season_badges.count > 6
+            %p.singing-profile__season-badge-more= "他 #{@season_badges.count - 6} 件のバッジを獲得しています。"
+        - else
+          .singing-profile__empty
+            %p バッジはまだありません。シーズンが終了すると、実績に応じてバッジが付与されます。
+
+      %section.singing-profile__section
+        .singing-profile__section-head
           %p.singing-profile__section-kicker Growth
           %h2 成長の記録
         - if @growth_diagnoses.present?

--- a/spec/helpers/singing/badges_helper_spec.rb
+++ b/spec/helpers/singing/badges_helper_spec.rb
@@ -1,0 +1,72 @@
+require "rails_helper"
+
+RSpec.describe Singing::BadgesHelper, type: :helper do
+  let(:season) do
+    FactoryBot.create(
+      :singing_ranking_season,
+      name: "2026年4月シーズン",
+      status: "closed",
+      starts_on: Date.new(2026, 4, 1),
+      ends_on: Date.new(2026, 4, 30)
+    )
+  end
+
+  def build_badge(badge_type:, awarded_at: Time.current)
+    FactoryBot.build(
+      :singing_badge,
+      badge_type: badge_type,
+      singing_ranking_season: season,
+      awarded_at: awarded_at
+    )
+  end
+
+  describe "#singing_badge_label" do
+    it "badge_type に対応するラベルを返すこと" do
+      expect(helper.singing_badge_label(build_badge(badge_type: "season_1st"))).to eq "今月の王者"
+      expect(helper.singing_badge_label(build_badge(badge_type: "rapid_growth"))).to eq "急成長シンガー"
+      expect(helper.singing_badge_label(build_badge(badge_type: "consecutive_participation"))).to eq "継続の証"
+    end
+  end
+
+  describe "#singing_badge_emoji" do
+    it "badge_type に対応する絵文字を返すこと" do
+      expect(helper.singing_badge_emoji(build_badge(badge_type: "season_1st"))).to eq "🥇"
+      expect(helper.singing_badge_emoji(build_badge(badge_type: "season_2nd"))).to eq "🥈"
+      expect(helper.singing_badge_emoji(build_badge(badge_type: "season_top3"))).to eq "🥉"
+      expect(helper.singing_badge_emoji(build_badge(badge_type: "season_top10"))).to eq "🎯"
+      expect(helper.singing_badge_emoji(build_badge(badge_type: "rapid_growth"))).to eq "📈"
+      expect(helper.singing_badge_emoji(build_badge(badge_type: "consecutive_participation"))).to eq "🔥"
+    end
+  end
+
+  describe "#singing_badge_display_text" do
+    it "絵文字とラベルを結合して返すこと" do
+      badge = build_badge(badge_type: "season_top10")
+      expect(helper.singing_badge_display_text(badge)).to eq "🎯 TOP10入り"
+    end
+  end
+
+  describe "#singing_badge_season_name" do
+    it "シーズン名を返すこと" do
+      badge = build_badge(badge_type: "season_1st")
+      expect(helper.singing_badge_season_name(badge)).to eq "2026年4月シーズン"
+    end
+  end
+
+  describe "#singing_badge_new?" do
+    it "awarded_at が7日以内なら true を返すこと" do
+      badge = build_badge(badge_type: "season_1st", awarded_at: 3.days.ago)
+      expect(helper.singing_badge_new?(badge)).to be true
+    end
+
+    it "awarded_at が7日より古いなら false を返すこと" do
+      badge = build_badge(badge_type: "season_1st", awarded_at: 8.days.ago)
+      expect(helper.singing_badge_new?(badge)).to be false
+    end
+
+    it "awarded_at が今日なら true を返すこと" do
+      badge = build_badge(badge_type: "season_1st", awarded_at: Time.current)
+      expect(helper.singing_badge_new?(badge)).to be true
+    end
+  end
+end

--- a/spec/requests/singing/diagnoses_spec.rb
+++ b/spec/requests/singing/diagnoses_spec.rb
@@ -1521,5 +1521,49 @@ RSpec.describe "Singing::Diagnoses", type: :request do
       expect(response.body).to include("総合スコア")
       expect(response.body).to include("AIコメントの生成に失敗しました")
     end
+
+    it "最新 closed シーズンのバッジを「今回のあなたの実績」に表示すること" do
+      sign_in singing_customer
+      closed_season = FactoryBot.create(
+        :singing_ranking_season,
+        name: "2026年4月シーズン",
+        status: "closed",
+        starts_on: Date.new(2026, 4, 1),
+        ends_on: Date.new(2026, 4, 30)
+      )
+      FactoryBot.create(
+        :singing_badge,
+        customer: singing_customer,
+        singing_ranking_season: closed_season,
+        badge_type: "season_1st",
+        awarded_at: 3.days.ago
+      )
+      diagnosis = FactoryBot.create(
+        :singing_diagnosis, :completed, :ranking_participant,
+        customer: singing_customer, overall_score: 90
+      )
+
+      get singing_diagnosis_path(diagnosis)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("今回のあなたの実績")
+      expect(response.body).to include("今月の王者")
+      expect(response.body).to include("🥇")
+      expect(response.body).to include("2026年4月シーズン")
+      expect(response.body).to include("NEW")
+    end
+
+    it "バッジがない場合は「今回のあなたの実績」セクションを表示しないこと" do
+      sign_in singing_customer
+      diagnosis = FactoryBot.create(
+        :singing_diagnosis, :completed, :ranking_participant,
+        customer: singing_customer, overall_score: 80
+      )
+
+      get singing_diagnosis_path(diagnosis)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).not_to include("今回のあなたの実績")
+    end
   end
 end

--- a/spec/requests/singing/users_spec.rb
+++ b/spec/requests/singing/users_spec.rb
@@ -150,6 +150,94 @@ RSpec.describe "Singing::Users", type: :request do
       expect(response.body).to include("診断に挑戦する")
     end
 
+    it "獲得した SingingBadge をシーズンバッジセクションに表示すること" do
+      sign_in other_customer
+      season = create(
+        :singing_ranking_season,
+        name: "2026年4月シーズン",
+        status: "closed",
+        starts_on: Date.new(2026, 4, 1),
+        ends_on: Date.new(2026, 4, 30)
+      )
+      create(
+        :singing_badge,
+        customer: singing_customer,
+        singing_ranking_season: season,
+        badge_type: "season_1st",
+        awarded_at: 3.days.ago
+      )
+
+      get singing_user_path(singing_customer)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("シーズンバッジ")
+      expect(response.body).to include("今月の王者")
+      expect(response.body).to include("🥇")
+      expect(response.body).to include("2026年4月シーズン")
+      expect(response.body).to include("NEW")
+    end
+
+    it "バッジが7日より古い場合 NEW を表示しないこと" do
+      sign_in other_customer
+      season = create(
+        :singing_ranking_season,
+        name: "2026年3月シーズン",
+        status: "closed",
+        starts_on: Date.new(2026, 3, 1),
+        ends_on: Date.new(2026, 3, 31)
+      )
+      create(
+        :singing_badge,
+        customer: singing_customer,
+        singing_ranking_season: season,
+        badge_type: "rapid_growth",
+        awarded_at: 10.days.ago
+      )
+
+      get singing_user_path(singing_customer)
+
+      expect(response.body).to include("急成長シンガー")
+      expect(response.body).not_to include("NEW")
+    end
+
+    it "バッジが6件を超える場合に「他X件」を表示すること" do
+      sign_in other_customer
+      season_a = create(
+        :singing_ranking_season,
+        name: "2026年4月シーズン",
+        status: "closed",
+        starts_on: Date.new(2026, 4, 1),
+        ends_on: Date.new(2026, 4, 30)
+      )
+      season_b = create(
+        :singing_ranking_season,
+        name: "2026年3月シーズン",
+        status: "closed",
+        starts_on: Date.new(2026, 3, 1),
+        ends_on: Date.new(2026, 3, 31)
+      )
+      SingingBadge::BADGE_TYPES.each do |badge_type|
+        create(:singing_badge, customer: singing_customer, singing_ranking_season: season_a,
+                               badge_type: badge_type, awarded_at: 30.days.ago)
+      end
+      create(:singing_badge, customer: singing_customer, singing_ranking_season: season_b,
+                             badge_type: "season_1st", awarded_at: 60.days.ago)
+
+      get singing_user_path(singing_customer)
+
+      expect(response.body).to include("他")
+      expect(response.body).to include("件のバッジを獲得しています。")
+    end
+
+    it "バッジがないユーザーのプロフィールでバッジセクションの空状態を表示すること" do
+      sign_in other_customer
+
+      get singing_user_path(singing_customer)
+
+      expect(response.body).to include("シーズンバッジ")
+      expect(response.body).to include("バッジはまだありません。")
+    end
+
     it "最新シーズン実績と非Premium向け案内を表示すること" do
       sign_in other_customer
       season = create(:singing_ranking_season, name: "2026年5月シーズン")


### PR DESCRIPTION
- Singing::BadgesHelper: badge_label / badge_emoji / badge_new? ヘルパー追加
- プロフィールページ: シーズンバッジ一覧（最大6件 + 超過時「他X件」）
- 診断結果ページ: 最新シーズンの「今回のあなたの実績」バッジ表示
- 7日以内の新バッジに NEWタグ + CSS pulse アニメーション
- N+1 対策: includes(:singing_ranking_season) を両コントローラーに設定
- spec 追加: helper 7件 / users request 4件 / diagnoses request 2件