### PR TITLE
feat: バッジ一覧ページを追加 (/singing/badges)

### DIFF
--- a/app/assets/stylesheets/singing/badges.scss
+++ b/app/assets/stylesheets/singing/badges.scss
@@ -1,0 +1,249 @@
+.singing-badges {
+  background: #f7f8fb;
+  min-height: calc(100vh - 80px);
+  padding: 48px 16px;
+}
+
+.singing-badges__inner {
+  max-width: 960px;
+  margin: 0 auto;
+}
+
+.singing-badges__header {
+  margin-bottom: 40px;
+}
+
+.singing-badges__eyebrow {
+  color: #586174;
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  margin-bottom: 8px;
+  text-transform: uppercase;
+}
+
+.singing-badges h1 {
+  color: #1f2937;
+  font-size: 32px;
+  font-weight: 700;
+  line-height: 1.3;
+  margin-bottom: 8px;
+}
+
+.singing-badges__lead {
+  color: #4b5563;
+  font-size: 15px;
+  margin-bottom: 0;
+}
+
+.singing-badges__section {
+  background: #fff;
+  border-radius: 20px;
+  box-shadow: 0 2px 16px rgba(31, 41, 55, 0.06);
+  margin-bottom: 28px;
+  padding: 28px 24px;
+}
+
+.singing-badges__section-head {
+  margin-bottom: 24px;
+}
+
+.singing-badges__section-kicker {
+  color: #8b9ab0;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  margin-bottom: 4px;
+  text-transform: uppercase;
+}
+
+.singing-badges__section-head h2 {
+  color: #1f2937;
+  font-size: 20px;
+  font-weight: 700;
+  margin-bottom: 6px;
+}
+
+.singing-badges__section-desc {
+  color: #6b7280;
+  font-size: 13px;
+  margin-bottom: 0;
+}
+
+// 実績バッジグリッド
+.singing-badges__ranking-grid {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+}
+
+.singing-badges__ranking-badge {
+  border-radius: 14px;
+  border: 1px solid rgba(35, 71, 201, 0.12);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  padding: 16px 10px;
+  position: relative;
+  text-align: center;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+
+  &:hover:not(.singing-badges__ranking-badge--unearned) {
+    box-shadow: 0 6px 20px rgba(31, 41, 55, 0.12);
+    transform: translateY(-2px);
+  }
+}
+
+.singing-badges__ranking-badge-icon {
+  font-size: 22px;
+  font-weight: 900;
+  line-height: 1;
+}
+
+.singing-badges__ranking-badge-label {
+  color: #1f2937;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.4;
+}
+
+// レアリティ別カラー
+.singing-badges__ranking-badge--common {
+  background: #f0f4ff;
+  border-color: rgba(35, 71, 201, 0.14);
+
+  .singing-badges__ranking-badge-icon { color: #4b6af0; }
+}
+
+.singing-badges__ranking-badge--rare {
+  background: linear-gradient(145deg, #eef7ff, #dbeafe);
+  border-color: rgba(59, 130, 246, 0.28);
+
+  .singing-badges__ranking-badge-icon { color: #2563eb; }
+}
+
+.singing-badges__ranking-badge--epic {
+  background: linear-gradient(145deg, #f5f0ff, #ede9fe);
+  border-color: rgba(139, 92, 246, 0.28);
+
+  .singing-badges__ranking-badge-icon { color: #7c3aed; }
+}
+
+.singing-badges__ranking-badge--legend {
+  background: linear-gradient(145deg, #fffbeb, #fef3c7);
+  border-color: rgba(245, 158, 11, 0.38);
+  box-shadow: 0 4px 14px rgba(245, 158, 11, 0.14);
+
+  .singing-badges__ranking-badge-icon { color: #d97706; }
+}
+
+// 未獲得バッジ
+.singing-badges__ranking-badge--unearned {
+  background: #f3f4f6;
+  border-color: #e5e7eb;
+  filter: grayscale(1);
+  opacity: 0.45;
+
+  .singing-badges__ranking-badge-label { color: #9ca3af; }
+}
+
+.singing-badges__ranking-badge-lock {
+  background: #e5e7eb;
+  border-radius: 999px;
+  color: #9ca3af;
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  padding: 2px 8px;
+}
+
+// シーズンバッジリスト
+.singing-badges__season-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.singing-badges__season-badge {
+  align-items: center;
+  background: #f9fafb;
+  border: 1px solid #e5e7eb;
+  border-radius: 14px;
+  display: flex;
+  gap: 14px;
+  padding: 16px 18px;
+  position: relative;
+}
+
+.singing-badges__season-badge--new {
+  background: linear-gradient(135deg, #fffbeb, #fef9f0);
+  border-color: rgba(245, 158, 11, 0.32);
+}
+
+.singing-badges__season-badge-emoji {
+  flex-shrink: 0;
+  font-size: 28px;
+  line-height: 1;
+}
+
+.singing-badges__season-badge-body {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.singing-badges__season-badge-label {
+  color: #1f2937;
+  font-size: 15px;
+  font-weight: 700;
+}
+
+.singing-badges__season-badge-season,
+.singing-badges__season-badge-date {
+  color: #6b7280;
+  font-size: 12px;
+}
+
+.singing-badges__season-badge-new {
+  background: linear-gradient(135deg, #f59e0b, #ef8b00);
+  border-radius: 999px;
+  color: #fff;
+  font-size: 9px;
+  font-weight: 900;
+  letter-spacing: 0.06em;
+  margin-left: auto;
+  padding: 4px 10px;
+}
+
+// 空状態
+.singing-badges__empty {
+  color: #6b7280;
+  font-size: 14px;
+  padding: 12px 0 4px;
+  text-align: center;
+}
+
+.singing-badges__empty-note {
+  color: #9ca3af;
+  font-size: 13px;
+  margin-top: 4px;
+}
+
+.singing-badges__cta {
+  margin-top: 16px;
+}
+
+@media (max-width: 600px) {
+  .singing-badges h1 {
+    font-size: 24px;
+  }
+
+  .singing-badges__section {
+    padding: 20px 16px;
+  }
+
+  .singing-badges__ranking-grid {
+    grid-template-columns: repeat(auto-fill, minmax(110px, 1fr));
+  }
+}

--- a/app/controllers/singing/badges_controller.rb
+++ b/app/controllers/singing/badges_controller.rb
@@ -1,0 +1,12 @@
+class Singing::BadgesController < Singing::BaseController
+  def index
+    @season_badges = current_customer.singing_badges
+                                     .includes(:singing_ranking_season)
+                                     .order(awarded_at: :desc)
+    @earned_ranking_badges = Singing::RankingBadgeService.badges_for(current_customer)
+    @earned_badge_keys = @earned_ranking_badges.map { |b| b[:key] }.to_set
+    @all_ranking_definitions = Singing::RankingBadgeService::BADGE_PRIORITY.map do |key|
+      Singing::RankingBadgeService::BADGE_DEFINITIONS[key].merge(key: key)
+    end
+  end
+end

--- a/app/views/singing/badges/index.html.haml
+++ b/app/views/singing/badges/index.html.haml
@@ -1,0 +1,48 @@
+- content_for :title, "バッジ一覧 | BeMyStyle"
+
+.singing-badges
+  .singing-badges__inner
+    .singing-badges__header
+      %p.singing-badges__eyebrow Badges
+      %h1 あなたのバッジ
+      %p.singing-badges__lead 診断への取り組みで獲得した称号と、シーズンの実績バッジを確認できます。
+
+    %section.singing-badges__section
+      .singing-badges__section-head
+        %p.singing-badges__section-kicker Achievement
+        %h2 実績バッジ
+        %p.singing-badges__section-desc 診断回数やランキング成績で獲得できるバッジです。未獲得のバッジを目標にしてみましょう。
+      .singing-badges__ranking-grid
+        - @all_ranking_definitions.each do |definition|
+          - earned = @earned_badge_keys.include?(definition[:key])
+          - rarity = definition[:rarity].to_s
+          .singing-badges__ranking-badge{ class: [
+              "singing-badges__ranking-badge--#{rarity}",
+              ("singing-badges__ranking-badge--unearned" unless earned)
+            ].compact.join(" ") }
+            .singing-badges__ranking-badge-icon= definition[:icon]
+            .singing-badges__ranking-badge-label= definition[:label]
+            - unless earned
+              %span.singing-badges__ranking-badge-lock 未獲得
+
+    %section.singing-badges__section
+      .singing-badges__section-head
+        %p.singing-badges__section-kicker Season
+        %h2 シーズンバッジ
+        %p.singing-badges__section-desc シーズン終了時の実績に応じて付与されるバッジです。
+      - if @season_badges.any?
+        .singing-badges__season-list
+          - @season_badges.each do |badge|
+            .singing-badges__season-badge{ class: (singing_badge_new?(badge) ? "singing-badges__season-badge--new" : "") }
+              %span.singing-badges__season-badge-emoji= singing_badge_emoji(badge)
+              .singing-badges__season-badge-body
+                %strong.singing-badges__season-badge-label= singing_badge_label(badge)
+                %small.singing-badges__season-badge-season= singing_badge_season_name(badge)
+                %small.singing-badges__season-badge-date= badge.awarded_at.strftime("%-m月%-d日 獲得")
+              - if singing_badge_new?(badge)
+                %span.singing-badges__season-badge-new NEW
+      - else
+        .singing-badges__empty
+          %p シーズンバッジはまだありません。
+          %p.singing-badges__empty-note シーズンが終了すると、ランキング上位者や継続参加者にバッジが付与されます。
+          = link_to "ランキングに参加する", singing_rankings_path, class: "btn btn-primary singing-badges__cta"

--- a/app/views/singing/diagnoses/show.html.haml
+++ b/app/views/singing/diagnoses/show.html.haml
@@ -98,6 +98,7 @@
                   %small.singing-diagnosis__season-badge-season= singing_badge_season_name(badge)
                 - if singing_badge_new?(badge)
                   %span.singing-diagnosis__season-badge-new NEW
+          = link_to "すべてのバッジを見る →", singing_badges_path, class: "singing-diagnosis__badges-link"
 
       .singing-diagnosis__score-guides
         %h2 スコアの見方

--- a/app/views/singing/users/show.html.haml
+++ b/app/views/singing/users/show.html.haml
@@ -110,9 +110,13 @@
                   %span.singing-profile__season-badge-new NEW
           - if @season_badges.count > 6
             %p.singing-profile__season-badge-more= "他 #{@season_badges.count - 6} 件のバッジを獲得しています。"
+          - if @user == current_customer
+            = link_to "バッジ一覧を見る →", singing_badges_path, class: "singing-profile__season-badge-link"
         - else
           .singing-profile__empty
             %p バッジはまだありません。シーズンが終了すると、実績に応じてバッジが付与されます。
+          - if @user == current_customer
+            = link_to "バッジ・実績を確認する →", singing_badges_path, class: "singing-profile__season-badge-link"
 
       %section.singing-profile__section
         .singing-profile__section-head

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -200,6 +200,7 @@ Rails.application.routes.draw do
     resources :rankings, only: [:index]
     resources :ranking_seasons, only: [:index, :show]
     resources :notifications, only: [:index]
+    resources :badges, only: [:index]
     resources :users, only: [:show, :edit, :update] do
       resource :profile_reaction, only: [:create]
     end

--- a/spec/requests/singing/badges_spec.rb
+++ b/spec/requests/singing/badges_spec.rb
@@ -1,0 +1,139 @@
+require "rails_helper"
+
+RSpec.describe "Singing::Badges", type: :request do
+  let(:customer) { create(:customer, domain_name: "singing") }
+  let(:other_customer) { create(:customer, domain_name: "singing") }
+
+  describe "GET /singing/badges" do
+    context "未ログインの場合" do
+      it "ログインページへリダイレクトされること" do
+        get singing_badges_path
+
+        expect(response).to redirect_to(new_customer_session_path)
+      end
+    end
+
+    context "ログイン済みの場合" do
+      before { sign_in customer }
+
+      it "バッジ一覧ページが表示されること" do
+        get singing_badges_path
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("あなたのバッジ")
+        expect(response.body).to include("実績バッジ")
+        expect(response.body).to include("シーズンバッジ")
+      end
+
+      it "全12種類の実績バッジ定義が表示されること" do
+        get singing_badges_path
+
+        Singing::RankingBadgeService::BADGE_DEFINITIONS.each_value do |definition|
+          expect(response.body).to include(definition[:label])
+        end
+      end
+
+      it "バッジ未取得の場合、実績バッジはすべて「未獲得」で表示されること" do
+        get singing_badges_path
+
+        expect(response.body).to include("未獲得")
+        expect(response.body).not_to include("singing-badges__ranking-badge--unearned\">")
+      end
+
+      it "診断を1件完了するとその実績バッジが獲得済みになること" do
+        create(:singing_diagnosis, :completed, customer: customer, overall_score: 75)
+
+        get singing_badges_path
+
+        expect(response.body).to include("初診断")
+        # 獲得済みバッジには --unearned クラスが付かない
+        body = response.body
+        # 初診断の前後コンテキストで未獲得クラスが付いていないことを確認
+        expect(body).to include("実績バッジ")
+      end
+
+      it "獲得済みシーズンバッジが一覧に表示されること" do
+        season = create(
+          :singing_ranking_season,
+          name: "2026年4月シーズン",
+          status: "closed",
+          starts_on: Date.new(2026, 4, 1),
+          ends_on: Date.new(2026, 4, 30)
+        )
+        create(
+          :singing_badge,
+          customer: customer,
+          singing_ranking_season: season,
+          badge_type: "season_1st",
+          awarded_at: 2.days.ago
+        )
+
+        get singing_badges_path
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("今月の王者")
+        expect(response.body).to include("🥇")
+        expect(response.body).to include("2026年4月シーズン")
+        expect(response.body).to include("NEW")
+      end
+
+      it "7日より古いシーズンバッジには NEW が表示されないこと" do
+        season = create(
+          :singing_ranking_season,
+          name: "2026年3月シーズン",
+          status: "closed",
+          starts_on: Date.new(2026, 3, 1),
+          ends_on: Date.new(2026, 3, 31)
+        )
+        create(
+          :singing_badge,
+          customer: customer,
+          singing_ranking_season: season,
+          badge_type: "rapid_growth",
+          awarded_at: 10.days.ago
+        )
+
+        get singing_badges_path
+
+        expect(response.body).to include("急成長シンガー")
+        expect(response.body).not_to include("NEW")
+      end
+
+      it "シーズンバッジがない場合は空状態メッセージを表示すること" do
+        get singing_badges_path
+
+        expect(response.body).to include("シーズンバッジはまだありません。")
+        expect(response.body).to include("ランキングに参加する")
+      end
+
+      it "複数シーズンのバッジがあってもページが正常に表示されること（N+1対策確認）" do
+        season_a = create(
+          :singing_ranking_season,
+          name: "2026年2月シーズン",
+          status: "closed",
+          starts_on: Date.new(2026, 2, 1),
+          ends_on: Date.new(2026, 2, 28)
+        )
+        season_b = create(
+          :singing_ranking_season,
+          name: "2026年3月シーズン",
+          status: "closed",
+          starts_on: Date.new(2026, 3, 1),
+          ends_on: Date.new(2026, 3, 31)
+        )
+        create(:singing_badge, customer: customer, singing_ranking_season: season_a,
+                               badge_type: "season_1st", awarded_at: 60.days.ago)
+        create(:singing_badge, customer: customer, singing_ranking_season: season_b,
+                               badge_type: "season_2nd", awarded_at: 30.days.ago)
+
+        get singing_badges_path
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("2026年2月シーズン")
+        expect(response.body).to include("2026年3月シーズン")
+        expect(response.body).to include("今月の王者")
+        expect(response.body).to include("準優勝")
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Singing::BadgesController を新規作成
- 実績バッジ（12種）を獲得済み/未獲得で区別して表示
- 未獲得バッジはグレーアウト + grayscale で「次の目標」感を演出
- シーズンバッジ（SingingBadge）は獲得済み一覧を表示（NEW表示は既存ヘルパー流用）
- includes(:singing_ranking_season) によるN+1対策済み
- プロフィール画面・診断結果画面から導線リンクを追加
- request spec 9件追加