### PR TITLE
feat: 診断結果画面に「あと少しでTOP10」進捗カードを追加

### DIFF
--- a/app/assets/stylesheets/singing/diagnoses.scss
+++ b/app/assets/stylesheets/singing/diagnoses.scss
@@ -4579,6 +4579,104 @@ $ranking-accent: #7c4dff;
 }
 
 // ============================================================
+// TOP10 progress card
+// ============================================================
+
+.singing-diagnosis__top10-card {
+  border-radius: 10px;
+  margin-bottom: 20px;
+  overflow: hidden;
+
+  &--top10 {
+    background: linear-gradient(135deg, #1a1240 0%, #2d1b69 100%);
+    box-shadow: 0 4px 16px rgba(124, 77, 255, 0.2);
+  }
+
+  &--close {
+    background: linear-gradient(135deg, #0a2e1a 0%, #14532d 100%);
+    box-shadow: 0 4px 16px rgba(20, 83, 45, 0.2);
+  }
+
+  &--far,
+  &--unranked,
+  &--no_score {
+    background: #f9fafb;
+    border: 1px solid #e5e7eb;
+  }
+
+  &--opt-out {
+    background: #f9fafb;
+    border: 1px solid #e5e7eb;
+  }
+}
+
+.singing-diagnosis__top10-card-inner {
+  padding: 20px 22px;
+}
+
+.singing-diagnosis__top10-label {
+  display: inline-block;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  margin-bottom: 8px;
+
+  .singing-diagnosis__top10-card--top10 &,
+  .singing-diagnosis__top10-card--close & {
+    color: #f5c842;
+  }
+
+  .singing-diagnosis__top10-card--far &,
+  .singing-diagnosis__top10-card--unranked &,
+  .singing-diagnosis__top10-card--no_score &,
+  .singing-diagnosis__top10-card--opt-out & {
+    color: #4b5563;
+  }
+}
+
+.singing-diagnosis__top10-rank {
+  font-size: 20px;
+  font-weight: 800;
+  margin: 4px 0 8px;
+  line-height: 1.2;
+
+  .singing-diagnosis__top10-card--top10 &,
+  .singing-diagnosis__top10-card--close & {
+    color: #fff;
+  }
+
+  .singing-diagnosis__top10-card--far &,
+  .singing-diagnosis__top10-card--unranked &,
+  .singing-diagnosis__top10-card--no_score & {
+    color: #1f2937;
+  }
+}
+
+.singing-diagnosis__top10-message {
+  font-size: 14px;
+  line-height: 1.65;
+  margin: 0 0 16px;
+
+  .singing-diagnosis__top10-card--top10 &,
+  .singing-diagnosis__top10-card--close & {
+    color: rgba(255, 255, 255, 0.88);
+  }
+
+  .singing-diagnosis__top10-card--far &,
+  .singing-diagnosis__top10-card--unranked &,
+  .singing-diagnosis__top10-card--no_score &,
+  .singing-diagnosis__top10-card--opt-out & {
+    color: #4b5563;
+  }
+}
+
+.singing-diagnosis__top10-actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+// ============================================================
 // Global singing navigation
 // ============================================================
 

--- a/app/controllers/singing/diagnoses_controller.rb
+++ b/app/controllers/singing/diagnoses_controller.rb
@@ -38,6 +38,10 @@ class Singing::DiagnosesController < Singing::BaseController
     if @diagnosis.completed?
       @growth_diagnoses = growth_diagnoses_for(@diagnosis)
       @diagnosis_season_badges = latest_season_badges_for(current_customer)
+      if @diagnosis.ranking_opt_in? && @diagnosis.overall_score.present?
+        @ranking_rank            = Singing::RankingQuery.position_for(current_customer.id)
+        @ranking_top10_threshold = top10_score_threshold
+      end
     end
   end
 
@@ -99,5 +103,25 @@ class Singing::DiagnosesController < Singing::BaseController
             .includes(:singing_ranking_season)
             .where(singing_ranking_season: latest_season)
             .order(awarded_at: :desc)
+  end
+
+  # 総合ランキング10位のスコアを返す。10人未満なら nil。
+  # pluck 1クエリで完結し N+1 を起こさない。
+  def top10_score_threshold
+    seen  = {}
+    count = 0
+    SingingDiagnosis
+      .completed
+      .where(ranking_opt_in: true)
+      .where.not(overall_score: nil)
+      .order(overall_score: :desc, id: :desc)
+      .pluck(:customer_id, :overall_score)
+      .each do |cid, score|
+        next if seen[cid]
+        seen[cid] = true
+        count += 1
+        return score if count == 10
+      end
+    nil
   end
 end

--- a/app/helpers/singing/diagnoses_helper.rb
+++ b/app/helpers/singing/diagnoses_helper.rb
@@ -1753,6 +1753,39 @@ module Singing::DiagnosesHelper
     "singing-diagnosis__reference-badge singing-diagnosis__reference-badge--#{suffix}"
   end
 
+  # TOP10 進捗データを返す。view に計算を持ち込まないようにここで完結させる。
+  #
+  # rank            : Singing::RankingQuery.position_for の戻り値（Integer or nil）
+  # top10_threshold : 総合ランキング10位のスコア（Integer or nil。10人未満のとき nil）
+  # score           : 今回診断の overall_score（Integer or nil）
+  #
+  # 戻り値:
+  #   { status: :top10,    rank: Integer }
+  #   { status: :close,    rank: Integer, gap: Integer }  # 11〜20位
+  #   { status: :far,      rank: Integer or nil, gap: Integer or nil }
+  #   { status: :unranked }  # ランキング圏外（同点・後発で押し出された等）
+  #   { status: :no_score }  # overall_score が nil
+  def singing_ranking_progress(rank, top10_threshold, score)
+    return { status: :no_score } if score.nil?
+
+    if rank.nil?
+      return { status: :unranked }
+    end
+
+    if rank <= 10
+      return { status: :top10, rank: rank }
+    end
+
+    # rank > 10 のとき、top10_threshold は必ず存在するが nil ガードも入れる
+    gap = if top10_threshold
+              diff = top10_threshold - score
+              # 同点で押し出されている場合 diff=0 → 最低1点表示
+              [diff, 1].max
+            end
+
+    { status: rank <= 20 ? :close : :far, rank: rank, gap: gap }
+  end
+
   private
 
   def comparison_delta_value(values)

--- a/app/views/singing/diagnoses/show.html.haml
+++ b/app/views/singing/diagnoses/show.html.haml
@@ -551,18 +551,45 @@
         %p.singing-diagnosis__polling-note 自動更新中です。完了または失敗になると更新は止まります。
 
     - if @diagnosis.completed?
-      - if @diagnosis.ranking_opt_in?
-        = link_to singing_rankings_path, class: "singing-diagnosis__ranking-nudge singing-diagnosis__ranking-nudge--joined" do
-          .singing-diagnosis__ranking-nudge-inner
-            %span.singing-diagnosis__ranking-nudge-badge ランキング参加中
-            %strong.singing-diagnosis__ranking-nudge-text 次はランキングにも挑戦しよう
-            %span.singing-diagnosis__ranking-nudge-link ランキングを見る &rarr;
+      - if @diagnosis.ranking_opt_in? && @diagnosis.overall_score.present?
+        - progress = singing_ranking_progress(@ranking_rank, @ranking_top10_threshold, @diagnosis.overall_score)
+        .singing-diagnosis__top10-card{ class: "singing-diagnosis__top10-card--#{progress[:status]}" }
+          .singing-diagnosis__top10-card-inner
+            - case progress[:status]
+            - when :top10
+              %span.singing-diagnosis__top10-label 🎉 TOP10 達成！
+              %p.singing-diagnosis__top10-rank 現在 #{progress[:rank]} 位
+              %p.singing-diagnosis__top10-message TOP10入りおめでとうございます！バッジも確認してみましょう。
+              .singing-diagnosis__top10-actions
+                = link_to "ランキングを見る", singing_rankings_path, class: "btn btn-primary"
+                = link_to "バッジを見る", singing_badges_path, class: "btn btn-secondary"
+            - when :close
+              %span.singing-diagnosis__top10-label 📈 あと少しでTOP10！
+              %p.singing-diagnosis__top10-rank 現在 #{progress[:rank]} 位
+              - if progress[:gap]
+                %p.singing-diagnosis__top10-message あと #{progress[:gap]} 点でTOP10入りです。もう一度挑戦してみましょう！
+              - else
+                %p.singing-diagnosis__top10-message もう少しでTOP10です。もう一度挑戦してみましょう！
+              .singing-diagnosis__top10-actions
+                = link_to "もう一度診断する", new_singing_diagnosis_path, class: "btn btn-primary"
+                = link_to "ランキングを見る", singing_rankings_path, class: "btn btn-secondary"
+                = link_to "バッジを見る", singing_badges_path, class: "btn btn-secondary"
+            - else
+              %span.singing-diagnosis__top10-label 🎯 TOP10を目指そう
+              - if progress[:rank]
+                %p.singing-diagnosis__top10-rank 現在 #{progress[:rank]} 位
+              %p.singing-diagnosis__top10-message コツコツ練習して、ランキングTOP10を目指しましょう！
+              .singing-diagnosis__top10-actions
+                = link_to "もう一度診断する", new_singing_diagnosis_path, class: "btn btn-primary"
+                = link_to "ランキングを見る", singing_rankings_path, class: "btn btn-secondary"
       - else
-        .singing-diagnosis__ranking-nudge.singing-diagnosis__ranking-nudge--opt-out
-          .singing-diagnosis__ranking-nudge-inner
-            %span.singing-diagnosis__ranking-nudge-badge--muted ランキング非参加
-            %p.singing-diagnosis__ranking-nudge-text この診断はランキング非参加です。次回診断時に「ランキングに参加する」を選ぶとスコアが公開されます。
-            = link_to "ランキングを見る", singing_rankings_path, class: "singing-diagnosis__ranking-nudge-link"
+        .singing-diagnosis__top10-card.singing-diagnosis__top10-card--opt-out
+          .singing-diagnosis__top10-card-inner
+            %span.singing-diagnosis__top10-label 📊 ランキング参加でバッジ獲得を目指そう
+            %p.singing-diagnosis__top10-message 次回の診断でランキングに参加すると、順位に応じてバッジを獲得できます。
+            .singing-diagnosis__top10-actions
+              = link_to "ランキングを見る", singing_rankings_path, class: "btn btn-secondary"
+              = link_to "バッジを見る", singing_badges_path, class: "btn btn-secondary"
 
     .singing-diagnosis__actions
       = link_to "もう一度診断する", new_singing_diagnosis_path, class: "btn btn-primary"

--- a/spec/helpers/singing/diagnoses_helper_spec.rb
+++ b/spec/helpers/singing/diagnoses_helper_spec.rb
@@ -1,6 +1,78 @@
 require 'rails_helper'
 
 RSpec.describe Singing::DiagnosesHelper, type: :helper do
+  describe "#singing_ranking_progress" do
+    context "overall_score が nil の場合" do
+      it ":no_score を返すこと" do
+        expect(helper.singing_ranking_progress(1, 80, nil)).to eq({ status: :no_score })
+      end
+    end
+
+    context "ランキング圏外（rank が nil）の場合" do
+      it ":unranked を返すこと" do
+        expect(helper.singing_ranking_progress(nil, 80, 70)).to eq({ status: :unranked })
+      end
+    end
+
+    context "1〜10位の場合" do
+      it "1位のとき :top10 と rank を返すこと" do
+        expect(helper.singing_ranking_progress(1, 90, 95)).to eq({ status: :top10, rank: 1 })
+      end
+
+      it "10位のとき :top10 と rank を返すこと" do
+        expect(helper.singing_ranking_progress(10, 80, 80)).to eq({ status: :top10, rank: 10 })
+      end
+    end
+
+    context "11〜20位（:close）の場合" do
+      it "スコア差分 gap を返すこと" do
+        result = helper.singing_ranking_progress(11, 85, 78)
+
+        expect(result[:status]).to eq :close
+        expect(result[:rank]).to eq 11
+        expect(result[:gap]).to eq 7
+      end
+
+      it "20位のとき :close を返すこと" do
+        result = helper.singing_ranking_progress(20, 85, 60)
+
+        expect(result[:status]).to eq :close
+        expect(result[:rank]).to eq 20
+        expect(result[:gap]).to eq 25
+      end
+
+      it "同点で押し出されている場合（gap=0）は gap=1 を返すこと" do
+        result = helper.singing_ranking_progress(11, 80, 80)
+
+        expect(result[:status]).to eq :close
+        expect(result[:gap]).to eq 1
+      end
+    end
+
+    context "21位以降（:far）の場合" do
+      it ":far と rank と gap を返すこと" do
+        result = helper.singing_ranking_progress(21, 85, 50)
+
+        expect(result[:status]).to eq :far
+        expect(result[:rank]).to eq 21
+        expect(result[:gap]).to eq 35
+      end
+    end
+
+    context "top10_threshold が nil（ランキング参加者が10人未満）の場合" do
+      it "rank が 1〜10 なら :top10 を返すこと" do
+        expect(helper.singing_ranking_progress(5, nil, 75)[:status]).to eq :top10
+      end
+
+      it "rank が 11 以上なら gap が nil のまま :far/:close を返すこと" do
+        result = helper.singing_ranking_progress(11, nil, 60)
+
+        expect(result[:status]).to eq :close
+        expect(result[:gap]).to be_nil
+      end
+    end
+  end
+
   describe "#singing_score_guide" do
     it "スコア説明文を返すこと" do
       guide = helper.singing_score_guide(:pitch)


### PR DESCRIPTION
ランキング参加診断でTOP10までの差分スコアと現在順位を表示し、
再診断・バッジ獲得へのモチベーションループを強化する。