### PR TITLE
feat: singing シーズン履歴ページを追加 (/singing/season_histories)

### DIFF
--- a/app/assets/stylesheets/singing/badges.scss
+++ b/app/assets/stylesheets/singing/badges.scss
@@ -247,3 +247,25 @@
     grid-template-columns: repeat(auto-fill, minmax(110px, 1fr));
   }
 }
+
+.singing-badges__nav {
+  margin-top: 32px;
+  padding-top: 24px;
+  border-top: 1px solid rgba(30, 41, 59, 0.08);
+  text-align: center;
+}
+
+.singing-badges__nav-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 14px;
+  font-weight: 600;
+  color: #2563eb;
+  text-decoration: none;
+
+  &:hover {
+    color: #1d4ed8;
+    text-decoration: underline;
+  }
+}

--- a/app/assets/stylesheets/singing/diagnoses.scss
+++ b/app/assets/stylesheets/singing/diagnoses.scss
@@ -3911,6 +3911,21 @@ $ranking-accent: #7c4dff;
   z-index: 1;
 }
 
+.singing-ranking__history-link {
+  display: inline-block;
+  margin-top: 14px;
+  font-size: 14px;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.72);
+  text-decoration: none;
+  letter-spacing: 0.01em;
+
+  &:hover {
+    color: rgba(255, 255, 255, 0.95);
+    text-decoration: underline;
+  }
+}
+
 // --- Responsive ---
 
 @media (max-width: 768px) {

--- a/app/assets/stylesheets/singing/season_histories.scss
+++ b/app/assets/stylesheets/singing/season_histories.scss
@@ -1,0 +1,435 @@
+// -----------------------------------------------
+// Singing Season History Page
+// -----------------------------------------------
+
+$history-bg:           #f7f8fb;
+$history-card-bg:      #ffffff;
+$history-border:       rgba(30, 41, 59, 0.08);
+$history-text-primary: #1f2937;
+$history-text-muted:   #6b7280;
+$history-active-color: #2563eb;
+$history-active-bg:    rgba(37, 99, 235, 0.07);
+$history-closed-color: #64748b;
+$history-accent:       #f97316;
+
+.singing-history {
+  background: $history-bg;
+  min-height: calc(100vh - 80px);
+  padding-bottom: 64px;
+}
+
+// ---- Hero ----
+.singing-history__hero {
+  background: linear-gradient(135deg, #0f172a 0%, #1e3a5f 60%, #1e293b 100%);
+  padding: 64px 16px 56px;
+  text-align: center;
+  color: #fff;
+}
+
+.singing-history__hero-inner {
+  max-width: 640px;
+  margin: 0 auto;
+}
+
+.singing-history__eyebrow {
+  display: inline-block;
+  margin-bottom: 12px;
+  padding: 4px 14px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.12);
+  color: rgba(255, 255, 255, 0.8);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.singing-history__hero-title {
+  margin: 0 0 14px;
+  font-size: 36px;
+  font-weight: 800;
+  line-height: 1.2;
+  letter-spacing: -0.01em;
+}
+
+.singing-history__hero-lead {
+  margin: 0;
+  font-size: 15px;
+  line-height: 1.8;
+  color: rgba(255, 255, 255, 0.75);
+}
+
+// ---- Inner ----
+.singing-history__inner {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 40px 16px 0;
+}
+
+// ---- Card list ----
+.singing-history__list {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+// ---- Card base ----
+.singing-history__card {
+  background: $history-card-bg;
+  border-radius: 16px;
+  border: 1px solid $history-border;
+  box-shadow: 0 2px 12px rgba(15, 23, 42, 0.06);
+  overflow: hidden;
+  transition: box-shadow 0.2s ease;
+
+  &:hover {
+    box-shadow: 0 8px 24px rgba(15, 23, 42, 0.10);
+  }
+
+  &--active {
+    border-color: rgba(37, 99, 235, 0.28);
+    box-shadow:
+      0 2px 12px rgba(15, 23, 42, 0.06),
+      0 0 0 1px rgba(37, 99, 235, 0.12);
+  }
+}
+
+// ---- Card head ----
+.singing-history__card-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 16px 20px 0;
+}
+
+.singing-history__status-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 10px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+
+  &--active {
+    background: $history-active-bg;
+    color: $history-active-color;
+
+    &::before {
+      content: "";
+      display: inline-block;
+      width: 6px;
+      height: 6px;
+      border-radius: 50%;
+      background: $history-active-color;
+      margin-right: 5px;
+      animation: historyPulse 1.6s ease-in-out infinite;
+    }
+  }
+
+  &--closed {
+    background: rgba(100, 116, 139, 0.1);
+    color: $history-closed-color;
+  }
+}
+
+@keyframes historyPulse {
+  0%, 100% { opacity: 1; }
+  50%       { opacity: 0.4; }
+}
+
+.singing-history__season-type {
+  font-size: 11px;
+  color: $history-text-muted;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+// ---- Season name & period ----
+.singing-history__season-name {
+  margin: 8px 20px 2px;
+  font-size: 20px;
+  font-weight: 700;
+  color: $history-text-primary;
+  letter-spacing: -0.01em;
+}
+
+.singing-history__period {
+  margin: 0 20px 16px;
+  font-size: 13px;
+  color: $history-text-muted;
+}
+
+// ---- Body ----
+.singing-history__body {
+  padding: 0 20px 16px;
+}
+
+.singing-history__challenge-note {
+  margin: 0 0 12px;
+  font-size: 13px;
+  font-weight: 600;
+  color: $history-active-color;
+}
+
+// ---- Result grid ----
+.singing-history__result {
+  display: flex;
+  gap: 16px;
+  margin-bottom: 14px;
+}
+
+.singing-history__result-item {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 80px;
+  padding: 10px 14px;
+  border-radius: 10px;
+  background: $history-bg;
+  border: 1px solid $history-border;
+}
+
+.singing-history__result-label {
+  font-size: 11px;
+  color: $history-text-muted;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.singing-history__result-value {
+  font-size: 22px;
+  font-weight: 800;
+  color: $history-text-primary;
+  line-height: 1.2;
+}
+
+.singing-history__result-pending {
+  font-size: 13px;
+  font-weight: 600;
+  color: $history-text-muted;
+}
+
+// ---- Badges ----
+.singing-history__badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 4px;
+}
+
+.singing-history__badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 12px;
+  border-radius: 999px;
+  background: linear-gradient(135deg, #fff8e1, #fef3c7);
+  border: 1px solid rgba(251, 191, 36, 0.4);
+  color: #78350f;
+  font-size: 13px;
+  font-weight: 700;
+  box-shadow: 0 2px 6px rgba(251, 191, 36, 0.2);
+}
+
+// ---- No entry ----
+.singing-history__no-entry {
+  padding: 20px;
+  border-radius: 12px;
+  background: linear-gradient(135deg, #f8fafc, #f1f5f9);
+  border: 1px dashed rgba(30, 41, 59, 0.16);
+  text-align: center;
+}
+
+.singing-history__no-entry-text {
+  margin: 0 0 4px;
+  font-size: 15px;
+  font-weight: 700;
+  color: $history-text-primary;
+}
+
+.singing-history__no-entry-sub {
+  margin: 0 0 14px;
+  font-size: 13px;
+  color: $history-text-muted;
+  line-height: 1.6;
+}
+
+.singing-history__entry-btn {
+  display: inline-flex;
+  align-items: center;
+  padding: 9px 20px;
+  border-radius: 999px;
+  background: linear-gradient(135deg, $history-accent, #ea580c);
+  color: #fff;
+  font-size: 14px;
+  font-weight: 700;
+  text-decoration: none;
+  box-shadow: 0 6px 16px rgba(249, 115, 22, 0.28);
+  transition: box-shadow 0.2s, transform 0.15s;
+
+  &:hover {
+    color: #fff;
+    text-decoration: none;
+    transform: translateY(-1px);
+    box-shadow: 0 10px 22px rgba(249, 115, 22, 0.36);
+  }
+}
+
+// ---- Card footer ----
+.singing-history__card-footer {
+  border-top: 1px solid $history-border;
+  padding: 12px 20px;
+}
+
+.singing-history__season-link {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 13px;
+  font-weight: 600;
+  color: $history-active-color;
+  text-decoration: none;
+  transition: color 0.15s;
+
+  &:hover {
+    color: darken($history-active-color, 10%);
+    text-decoration: none;
+  }
+}
+
+.singing-history__season-link-arrow {
+  font-size: 16px;
+  transition: transform 0.15s;
+
+  .singing-history__season-link:hover & {
+    transform: translateX(3px);
+  }
+}
+
+// ---- Empty state ----
+.singing-history__empty {
+  padding: 64px 24px;
+  text-align: center;
+  background: $history-card-bg;
+  border-radius: 16px;
+  border: 1px solid $history-border;
+}
+
+.singing-history__empty-icon {
+  font-size: 40px;
+  margin-bottom: 16px;
+}
+
+.singing-history__empty-title {
+  margin: 0 0 8px;
+  font-size: 20px;
+  font-weight: 700;
+  color: $history-text-primary;
+}
+
+.singing-history__empty-text {
+  margin: 0 0 24px;
+  font-size: 14px;
+  color: $history-text-muted;
+  line-height: 1.8;
+}
+
+.singing-history__empty-btn {
+  display: inline-flex;
+  align-items: center;
+  padding: 12px 28px;
+  border-radius: 999px;
+  background: linear-gradient(135deg, $history-accent, #ea580c);
+  color: #fff;
+  font-weight: 700;
+  text-decoration: none;
+  box-shadow: 0 8px 20px rgba(249, 115, 22, 0.3);
+
+  &:hover {
+    color: #fff;
+    text-decoration: none;
+    transform: translateY(-1px);
+  }
+}
+
+// ---- Bottom nav ----
+.singing-history__nav {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 12px;
+  margin-top: 40px;
+  padding-top: 32px;
+  border-top: 1px solid $history-border;
+}
+
+.singing-history__nav-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 10px 20px;
+  border-radius: 999px;
+  background: #fff;
+  border: 1px solid $history-border;
+  color: $history-text-primary;
+  font-size: 14px;
+  font-weight: 600;
+  text-decoration: none;
+  box-shadow: 0 2px 8px rgba(15, 23, 42, 0.06);
+  transition: box-shadow 0.2s, transform 0.15s;
+
+  &:hover {
+    color: $history-text-primary;
+    text-decoration: none;
+    box-shadow: 0 6px 16px rgba(15, 23, 42, 0.10);
+    transform: translateY(-1px);
+  }
+
+  &--primary {
+    background: linear-gradient(135deg, $history-accent, #ea580c);
+    color: #fff;
+    border-color: transparent;
+    box-shadow: 0 6px 16px rgba(249, 115, 22, 0.28);
+
+    &:hover {
+      color: #fff;
+      transform: translateY(-1px);
+      box-shadow: 0 10px 22px rgba(249, 115, 22, 0.36);
+    }
+  }
+}
+
+.singing-history__nav-icon {
+  font-size: 15px;
+}
+
+// ---- Responsive ----
+@media (max-width: 640px) {
+  .singing-history__hero {
+    padding: 48px 16px 40px;
+  }
+
+  .singing-history__hero-title {
+    font-size: 28px;
+  }
+
+  .singing-history__result {
+    flex-wrap: wrap;
+  }
+
+  .singing-history__result-item {
+    flex: 1 1 auto;
+  }
+
+  .singing-history__nav {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .singing-history__nav-link {
+    justify-content: center;
+  }
+}

--- a/app/controllers/singing/season_histories_controller.rb
+++ b/app/controllers/singing/season_histories_controller.rb
@@ -1,0 +1,53 @@
+class Singing::SeasonHistoriesController < Singing::BaseController
+  SeasonHistoryEntry = Struct.new(:season, :entry, :badges, keyword_init: true) do
+    def participated?
+      entry.present?
+    end
+
+    def active?
+      season.status == "active"
+    end
+
+    def closed?
+      season.status == "closed"
+    end
+
+    def rank
+      entry&.rank
+    end
+
+    def score
+      entry&.score
+    end
+  end
+
+  def index
+    seasons = SingingRankingSeason
+                .where(status: %w[active closed])
+                .order(starts_on: :desc)
+    season_ids = seasons.map(&:id)
+
+    my_entries = SingingSeasonRankingEntry
+                   .where(
+                     customer_id: current_customer.id,
+                     singing_ranking_season_id: season_ids,
+                     category: "overall"
+                   )
+                   .index_by(&:singing_ranking_season_id)
+
+    my_badges = SingingBadge
+                  .where(
+                    customer_id: current_customer.id,
+                    singing_ranking_season_id: season_ids
+                  )
+                  .group_by(&:singing_ranking_season_id)
+
+    @season_histories = seasons.map do |season|
+      SeasonHistoryEntry.new(
+        season: season,
+        entry:  my_entries[season.id],
+        badges: my_badges[season.id] || []
+      )
+    end
+  end
+end

--- a/app/views/singing/badges/index.html.haml
+++ b/app/views/singing/badges/index.html.haml
@@ -46,3 +46,7 @@
           %p シーズンバッジはまだありません。
           %p.singing-badges__empty-note シーズンが終了すると、ランキング上位者や継続参加者にバッジが付与されます。
           = link_to "ランキングに参加する", singing_rankings_path, class: "btn btn-primary singing-badges__cta"
+
+    .singing-badges__nav
+      = link_to singing_season_histories_path, class: "singing-badges__nav-link" do
+        過去のシーズン成績を見る →

--- a/app/views/singing/rankings/index.html.haml
+++ b/app/views/singing/rankings/index.html.haml
@@ -82,3 +82,4 @@
         %br
         成長の記録が、あなただけの物語になります。
       = link_to "歌唱・演奏診断を始める", new_singing_diagnosis_path, class: "btn btn-primary singing-ranking__cta-btn"
+      = link_to "シーズン履歴を見る", singing_season_histories_path, class: "singing-ranking__history-link"

--- a/app/views/singing/season_histories/index.html.haml
+++ b/app/views/singing/season_histories/index.html.haml
@@ -1,0 +1,101 @@
+- content_for :title, "シーズン履歴 | BeMyStyle"
+
+.singing-history
+  .singing-history__hero
+    .singing-history__hero-inner
+      %p.singing-history__eyebrow SEASON HISTORY
+      %h1.singing-history__hero-title あなたのシーズン履歴
+      %p.singing-history__hero-lead
+        月ごとの成績を振り返り、成長の軌跡を確認できます。
+        %br
+        挑戦し続けることが、あなた自身の物語になります。
+
+  .singing-history__inner
+    - if @season_histories.present?
+      .singing-history__list
+        - @season_histories.each do |h|
+          .singing-history__card{ class: "singing-history__card--#{h.season.status}" }
+
+            .singing-history__card-head
+              %span.singing-history__status-badge{ class: "singing-history__status-badge--#{h.season.status}" }
+                - if h.active?
+                  開催中
+                - else
+                  終了
+              %span.singing-history__season-type= h.season.season_type == "monthly" ? "月間" : h.season.season_type
+
+            %h2.singing-history__season-name= h.season.name
+            %p.singing-history__period
+              = h.season.starts_on.strftime("%Y/%m/%d")
+              〜
+              = h.season.ends_on.strftime("%Y/%m/%d")
+
+            .singing-history__body
+              - if h.participated?
+                - if h.active?
+                  %p.singing-history__challenge-note 今月のランキングに挑戦中
+                - else
+                  %p.singing-history__challenge-note 参加済み
+
+                .singing-history__result
+                  .singing-history__result-item
+                    %span.singing-history__result-label 順位
+                    %span.singing-history__result-value
+                      - if h.rank.present?
+                        %strong= "#{h.rank}位"
+                      - else
+                        %span.singing-history__result-pending 集計中
+                  .singing-history__result-item
+                    %span.singing-history__result-label スコア
+                    %span.singing-history__result-value
+                      - if h.score.present?
+                        %strong= h.score
+                      - else
+                        %span.singing-history__result-pending 集計中
+
+                - if h.badges.any?
+                  .singing-history__badges
+                    - h.badges.each do |badge|
+                      %span.singing-history__badge{ title: badge.label }
+                        = badge.emoji
+                        = badge.label
+
+              - else
+                .singing-history__no-entry
+                  %p.singing-history__no-entry-text まだ参加していません
+                  %p.singing-history__no-entry-sub
+                    - if h.active?
+                      今月まだ間に合います。診断してランキングに参加しましょう。
+                    - else
+                      このシーズンは参加しませんでした。次のシーズンで挑戦してみましょう。
+                  - if h.active?
+                    = link_to "今月の診断を始める", new_singing_diagnosis_path, class: "btn singing-history__entry-btn"
+
+            .singing-history__card-footer
+              = link_to singing_ranking_season_path(h.season), class: "singing-history__season-link" do
+                - if h.active?
+                  今月のシーズンを確認する
+                - else
+                  このシーズンの結果を見る
+                %span.singing-history__season-link-arrow →
+
+    - else
+      .singing-history__empty
+        %p.singing-history__empty-icon ☆
+        %p.singing-history__empty-title まだシーズンが開催されていません
+        %p.singing-history__empty-text
+          シーズンが始まったら、ここに成績が記録されていきます。
+          %br
+          まずは診断を受けてみましょう。
+        = link_to "歌唱・演奏診断を始める", new_singing_diagnosis_path, class: "btn btn-primary singing-history__empty-btn"
+
+    .singing-history__nav
+      = link_to singing_badges_path, class: "singing-history__nav-link" do
+        %span.singing-history__nav-icon 🏅
+        バッジ一覧を見る
+      = link_to singing_rankings_path, class: "singing-history__nav-link" do
+        %span.singing-history__nav-icon ♛
+        ランキングへ
+      = link_to new_singing_diagnosis_path, class: "singing-history__nav-link singing-history__nav-link--primary" do
+        %span.singing-history__nav-icon ♪
+        診断する

--- a/app/views/singing/shared/_header.html.haml
+++ b/app/views/singing/shared/_header.html.haml
@@ -15,6 +15,7 @@
           - unchecked_count = current_customer.passive_notifications.where(checked: false).count
           - if unchecked_count.positive?
             %span.singing-nav__badge= unchecked_count
+      = link_to "シーズン履歴", singing_season_histories_path, class: "singing-nav__link#{' singing-nav__link--active' if current_page?(singing_season_histories_path)}"
       = link_to "料金プラン", public_singing_lp_path(anchor: "lp-section"), class: "singing-nav__link"
 
     .singing-nav__right
@@ -70,6 +71,7 @@
             - if unchecked_count.positive?
               %span.singing-nav__badge= unchecked_count
         = link_to "ランキング", singing_rankings_path, class: "singing-nav__mobile-link singing-nav__mobile-link--cta"
+        = link_to "シーズン履歴", singing_season_histories_path, class: "singing-nav__mobile-link"
         = link_to "BeMyStyleへ", root_path, class: "singing-nav__mobile-link singing-nav__mobile-link--cta"
         = link_to "料金プラン", public_singing_lp_path(anchor: "lp-section"), class: "singing-nav__mobile-link"
         - if current_customer

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -199,6 +199,7 @@ Rails.application.routes.draw do
     resources :diagnoses, only: [:index, :new, :create, :show]
     resources :rankings, only: [:index]
     resources :ranking_seasons, only: [:index, :show]
+    resources :season_histories, only: [:index]
     resources :notifications, only: [:index]
     resources :badges, only: [:index]
     resources :users, only: [:show, :edit, :update] do

--- a/spec/requests/singing/season_histories_spec.rb
+++ b/spec/requests/singing/season_histories_spec.rb
@@ -1,0 +1,206 @@
+require "rails_helper"
+
+RSpec.describe "Singing::SeasonHistories", type: :request do
+  let(:customer) { create(:customer, domain_name: "singing") }
+
+  describe "GET /singing/season_histories" do
+    context "未ログインの場合" do
+      it "ログインページへリダイレクトされること" do
+        get singing_season_histories_path
+
+        expect(response).to redirect_to(new_customer_session_path)
+      end
+    end
+
+    context "ログイン済みの場合" do
+      before { sign_in customer }
+
+      context "シーズンが存在しない場合" do
+        it "200 OK でページが表示され、空状態メッセージが出ること" do
+          get singing_season_histories_path
+
+          expect(response).to have_http_status(:ok)
+          expect(response.body).to include("あなたのシーズン履歴")
+          expect(response.body).to include("まだシーズンが開催されていません")
+        end
+      end
+
+      context "開催中シーズンが存在するが未参加の場合" do
+        let!(:active_season) do
+          create(:singing_ranking_season, :current,
+                 name: "2026年5月シーズン")
+        end
+
+        it "シーズン名と未参加メッセージが表示されること" do
+          get singing_season_histories_path
+
+          expect(response).to have_http_status(:ok)
+          expect(response.body).to include("2026年5月シーズン")
+          expect(response.body).to include("開催中")
+          expect(response.body).to include("まだ参加していません")
+          expect(response.body).to include("今月まだ間に合います")
+        end
+
+        it "診断を始めるCTAリンクが表示されること" do
+          get singing_season_histories_path
+
+          expect(response.body).to include("今月の診断を始める")
+        end
+      end
+
+      context "開催中シーズンに参加済みの場合" do
+        let!(:active_season) do
+          create(:singing_ranking_season, :current,
+                 name: "2026年5月シーズン")
+        end
+        let!(:entry) do
+          create(:singing_season_ranking_entry,
+                 singing_ranking_season: active_season,
+                 customer: customer,
+                 category: "overall",
+                 rank: 3,
+                 score: 85)
+        end
+
+        it "順位とスコアが表示されること" do
+          get singing_season_histories_path
+
+          expect(response).to have_http_status(:ok)
+          expect(response.body).to include("3位")
+          expect(response.body).to include("85")
+          expect(response.body).to include("今月のランキングに挑戦中")
+        end
+      end
+
+      context "終了済みシーズンに参加済みでバッジを獲得している場合" do
+        let!(:closed_season) do
+          create(:singing_ranking_season, :closed,
+                 name: "2026年4月シーズン")
+        end
+        let!(:entry) do
+          create(:singing_season_ranking_entry,
+                 singing_ranking_season: closed_season,
+                 customer: customer,
+                 category: "overall",
+                 rank: 1,
+                 score: 92)
+        end
+        let!(:badge) do
+          create(:singing_badge,
+                 customer: customer,
+                 singing_ranking_season: closed_season,
+                 badge_type: "season_1st",
+                 awarded_at: 10.days.ago)
+        end
+
+        it "順位・スコア・バッジが表示されること" do
+          get singing_season_histories_path
+
+          expect(response).to have_http_status(:ok)
+          expect(response.body).to include("2026年4月シーズン")
+          expect(response.body).to include("終了")
+          expect(response.body).to include("1位")
+          expect(response.body).to include("92")
+          expect(response.body).to include("🥇")
+          expect(response.body).to include("今月の王者")
+        end
+      end
+
+      context "終了済みシーズンに未参加の場合" do
+        let!(:closed_season) do
+          create(:singing_ranking_season, :closed,
+                 name: "2026年4月シーズン")
+        end
+
+        it "未参加メッセージと再挑戦を促す文言が表示されること" do
+          get singing_season_histories_path
+
+          expect(response.body).to include("まだ参加していません")
+          expect(response.body).to include("次のシーズンで挑戦してみましょう")
+        end
+
+        it "終了シーズンに診断CTAボタンは表示されないこと" do
+          get singing_season_histories_path
+
+          expect(response.body).not_to include("今月の診断を始める")
+        end
+      end
+
+      context "複数シーズンが存在する場合（N+1 チェック）" do
+        let!(:season_a) { create(:singing_ranking_season, :closed, name: "2026年3月シーズン") }
+        let!(:season_b) { create(:singing_ranking_season, :closed, name: "2026年4月シーズン") }
+        let!(:season_c) { create(:singing_ranking_season, :current, name: "2026年5月シーズン") }
+
+        before do
+          create(:singing_season_ranking_entry,
+                 singing_ranking_season: season_a, customer: customer,
+                 category: "overall", rank: 5, score: 70)
+          create(:singing_badge,
+                 customer: customer, singing_ranking_season: season_a,
+                 badge_type: "season_top10", awarded_at: 60.days.ago)
+          create(:singing_season_ranking_entry,
+                 singing_ranking_season: season_c, customer: customer,
+                 category: "overall", rank: 2, score: 88)
+        end
+
+        it "全シーズンが正常に表示されること" do
+          get singing_season_histories_path
+
+          expect(response).to have_http_status(:ok)
+          expect(response.body).to include("2026年3月シーズン")
+          expect(response.body).to include("2026年4月シーズン")
+          expect(response.body).to include("2026年5月シーズン")
+        end
+
+        it "参加済みシーズンのデータが表示されること" do
+          get singing_season_histories_path
+
+          expect(response.body).to include("5位")
+          expect(response.body).to include("🎯")
+          expect(response.body).to include("2位")
+          expect(response.body).to include("88")
+        end
+
+        it "未参加シーズンには未参加メッセージが表示されること" do
+          get singing_season_histories_path
+
+          expect(response.body).to include("まだ参加していません")
+        end
+      end
+
+      context "他ユーザーのエントリは表示されないこと" do
+        let(:other_customer) { create(:customer, domain_name: "singing") }
+        let!(:active_season) { create(:singing_ranking_season, :current, name: "2026年5月シーズン") }
+        let!(:other_entry) do
+          create(:singing_season_ranking_entry,
+                 singing_ranking_season: active_season,
+                 customer: other_customer,
+                 category: "overall",
+                 rank: 1,
+                 score: 99)
+        end
+
+        it "自分が未参加であれば他ユーザーのスコアは表示されないこと" do
+          get singing_season_histories_path
+
+          expect(response.body).not_to include("99")
+          expect(response.body).to include("まだ参加していません")
+        end
+      end
+
+      context "ナビゲーションリンク" do
+        it "バッジ一覧へのリンクが含まれること" do
+          get singing_season_histories_path
+
+          expect(response.body).to include(singing_badges_path)
+        end
+
+        it "ランキングへのリンクが含まれること" do
+          get singing_season_histories_path
+
+          expect(response.body).to include(singing_rankings_path)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
ログイン中ユーザーが過去・現在のシーズン成績（順位・スコア・獲得バッジ）を
一覧で振り返れる個人向けページを追加した。
クエリ3本固定でN+1を回避し、未参加シーズンにはポジティブなCTAを表示する。