### PR TITLE
feat: 成長ランキングUIの訴求を改善

### DIFF
--- a/app/assets/stylesheets/singing/diagnoses.scss
+++ b/app/assets/stylesheets/singing/diagnoses.scss
@@ -4305,6 +4305,26 @@ $ranking-accent: #7c4dff;
   padding: 2px 8px;
 }
 
+.singing-ranking__growth-cta {
+  margin-top: 8px;
+  padding: 28px 24px;
+  background: linear-gradient(135deg, #f0fdf4 0%, #ecfdf5 100%);
+  border: 1px solid #bbf7d0;
+  border-radius: 12px;
+  text-align: center;
+}
+
+.singing-ranking__growth-cta-message {
+  color: #166534;
+  font-size: 14px;
+  line-height: 1.8;
+  margin: 0 0 16px;
+}
+
+.singing-ranking__growth-cta-btn {
+  display: inline-block;
+}
+
 // --- Season Ranking ---
 
 .singing-ranking__tab-badge--season {

--- a/app/views/singing/rankings/_growth.html.haml
+++ b/app/views/singing/rankings/_growth.html.haml
@@ -1,12 +1,12 @@
 -# growth_rankings: Array<Singing::RankingQuery::GrowthEntry>
 -# ranking_plan_context: Hash
 
--# FUTURE: can_join_growth_ranking=false のユーザーにはアップセルバナーを表示（Core解放時）
+-# FUTURE: can_join_growth_ranking=true になったタイミングでこのブロックを削除し、プレミアム向け追加機能に差し替える
 - unless ranking_plan_context[:can_join_growth_ranking]
   .singing-ranking__plan-nudge
     %span.singing-ranking__plan-nudge-icon ✦
     .singing-ranking__plan-nudge-text
-      成長ランキングはCoreプラン以上でフル解放予定です。現在はすべてのユーザーが閲覧できます。
+      スコアが上がるたびにランキングに反映されます。今すぐ診断してあなたの成長を刻みましょう！
 
 .singing-ranking__growth-intro
   %p.singing-ranking__growth-intro-text
@@ -44,3 +44,10 @@
             = "#{entry.previous_diagnosis.overall_score}点 → #{entry.latest_diagnosis.overall_score}点"
           - if (title = singing_growth_title(entry.growth_score))
             %span.singing-ranking__growth-badge= title
+
+  .singing-ranking__growth-cta
+    %p.singing-ranking__growth-cta-message
+      あなたも次回の診断でランクインできるかもしれません。
+      %br
+      スコアが伸びた分だけ、ランキングに刻まれます。
+    = link_to "今すぐ診断する", new_singing_diagnosis_path, class: "btn btn-primary singing-ranking__growth-cta-btn"

--- a/app/views/singing/rankings/index.html.haml
+++ b/app/views/singing/rankings/index.html.haml
@@ -6,7 +6,7 @@
       %p.singing-ranking__hero-intro
         診断に参加したみんなのチャレンジ結果を確認できます。
         %br
-        総合ランキングとシーズンランキングを切り替えて楽しめます。
+        総合・成長・シーズンの3つのランキングで、あなたの歩みを刻みましょう。
       - case @ranking_type
       - when "growth"
         %p.singing-ranking__hero-subtitle

--- a/spec/requests/singing/rankings_spec.rb
+++ b/spec/requests/singing/rankings_spec.rb
@@ -375,6 +375,28 @@ RSpec.describe "Singing::Rankings", type: :request do
 
           expect(response.body).to include("まだ成長ランキング参加者はいません")
         end
+
+        it "参加者がいない場合は下部CTAを表示しないこと" do
+          get singing_rankings_path(type: "growth")
+
+          expect(response.body).not_to include("あなたも次回の診断でランクインできるかもしれません")
+        end
+
+        it "参加者がいる場合は下部CTAを表示すること" do
+          FactoryBot.create(
+            :singing_diagnosis, :completed,
+            customer: other_customer, overall_score: 60, ranking_opt_in: false,
+            created_at: 2.days.ago
+          )
+          FactoryBot.create(
+            :singing_diagnosis, :completed, :ranking_participant,
+            customer: other_customer, overall_score: 80, created_at: 1.day.ago
+          )
+
+          get singing_rankings_path(type: "growth")
+
+          expect(response.body).to include("あなたも次回の診断でランクインできるかもしれません")
+        end
       end
 
       context "GET /singing/rankings?type=season（シーズンランキング）" do


### PR DESCRIPTION
- hero introに成長ランキングへの言及を追加（3種類を明示）
- plan nudgeを「Core解放予定」から前向きな診断促進メッセージに変更
- 参加者がいる場合のみ下部CTAを表示（「あなたも次回ランクインできるかも」）
- 下部CTAのSCSSスタイル追加
- 上記に対応するrequest specを追加（参加者あり/なし両ケース）