### PR TITLE
feat: 診断結果画面に新着バッジ獲得祝福カードを追加

### DIFF
--- a/app/assets/stylesheets/singing/diagnoses.scss
+++ b/app/assets/stylesheets/singing/diagnoses.scss
@@ -5937,6 +5937,94 @@ $ranking-accent: #7c4dff;
   vertical-align: middle;
 }
 
+// ─── バッジ獲得祝福カード（診断結果画面）────────────────────────────────
+.singing-diagnosis__badge-celebration {
+  background: linear-gradient(135deg, #fffbea 0%, #fef3c7 100%);
+  border: 1.5px solid #f5c842;
+  border-left: 5px solid #f59e0b;
+  border-radius: 12px;
+  margin-bottom: 20px;
+  padding: 22px 22px 18px;
+}
+
+.singing-diagnosis__badge-celebration-header {
+  align-items: center;
+  display: flex;
+  gap: 10px;
+  margin-bottom: 16px;
+}
+
+.singing-diagnosis__badge-celebration-icon {
+  font-size: 26px;
+  line-height: 1;
+}
+
+.singing-diagnosis__badge-celebration-title {
+  color: #92400e;
+  font-size: 17px;
+  font-weight: 800;
+  margin: 0;
+}
+
+.singing-diagnosis__badge-celebration-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-bottom: 18px;
+}
+
+.singing-diagnosis__badge-celebration-item {
+  align-items: center;
+  animation: singing-badge-new-pulse 1.6s ease-in-out 3;
+  background: #fff;
+  border: 1px solid #f5c842;
+  border-radius: 10px;
+  display: flex;
+  gap: 12px;
+  padding: 12px 16px;
+}
+
+.singing-diagnosis__badge-celebration-emoji {
+  flex-shrink: 0;
+  font-size: 30px;
+  line-height: 1;
+}
+
+.singing-diagnosis__badge-celebration-body {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.singing-diagnosis__badge-celebration-label {
+  color: #1f2937;
+  font-size: 15px;
+  font-weight: 700;
+}
+
+.singing-diagnosis__badge-celebration-season {
+  color: #92400e;
+  font-size: 12px;
+}
+
+.singing-diagnosis__badge-celebration-new {
+  background: linear-gradient(135deg, #f59e0b, #ef8b00);
+  border-radius: 999px;
+  color: #fff;
+  flex-shrink: 0;
+  font-size: 9px;
+  font-weight: 900;
+  letter-spacing: 0.06em;
+  padding: 4px 10px;
+}
+
+.singing-diagnosis__badge-celebration-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
 // ─── シーズンバッジ（診断結果画面）───────────────────────────────────
 @keyframes singing-badge-new-pulse {
   0%, 100% { box-shadow: 0 0 0 0 rgba(255, 200, 0, 0.4); }

--- a/app/controllers/singing/diagnoses_controller.rb
+++ b/app/controllers/singing/diagnoses_controller.rb
@@ -38,6 +38,7 @@ class Singing::DiagnosesController < Singing::BaseController
     if @diagnosis.completed?
       @growth_diagnoses = growth_diagnoses_for(@diagnosis)
       @diagnosis_season_badges = latest_season_badges_for(current_customer)
+      @new_season_badges = @diagnosis_season_badges.select { |b| b.awarded_at >= 7.days.ago }
       if @diagnosis.ranking_opt_in? && @diagnosis.overall_score.present?
         @ranking_rank            = Singing::RankingQuery.position_for(current_customer.id)
         @ranking_top10_threshold = top10_score_threshold

--- a/app/views/singing/diagnoses/show.html.haml
+++ b/app/views/singing/diagnoses/show.html.haml
@@ -85,6 +85,24 @@
               %small= card[:short_label]
               %p= card[:comment]
 
+      - if @new_season_badges.present?
+        .singing-diagnosis__badge-celebration
+          .singing-diagnosis__badge-celebration-header
+            %span.singing-diagnosis__badge-celebration-icon 🎉
+            %h2.singing-diagnosis__badge-celebration-title 新しいバッジを獲得しました！
+          .singing-diagnosis__badge-celebration-list
+            - @new_season_badges.each do |badge|
+              .singing-diagnosis__badge-celebration-item
+                %span.singing-diagnosis__badge-celebration-emoji= singing_badge_emoji(badge)
+                .singing-diagnosis__badge-celebration-body
+                  %strong.singing-diagnosis__badge-celebration-label= singing_badge_label(badge)
+                  %small.singing-diagnosis__badge-celebration-season= singing_badge_season_name(badge)
+                %span.singing-diagnosis__badge-celebration-new NEW
+          .singing-diagnosis__badge-celebration-links
+            = link_to "バッジ一覧を見る", singing_badges_path, class: "btn btn-primary"
+            = link_to "シーズン履歴を見る", singing_season_histories_path, class: "btn btn-secondary"
+            = link_to "もう一度診断する", new_singing_diagnosis_path, class: "btn btn-secondary"
+
       - if @diagnosis_season_badges.present?
         .singing-diagnosis__season-badges
           %h2 今回のあなたの実績

--- a/spec/requests/singing/diagnoses_spec.rb
+++ b/spec/requests/singing/diagnoses_spec.rb
@@ -1553,6 +1553,63 @@ RSpec.describe "Singing::Diagnoses", type: :request do
       expect(response.body).to include("NEW")
     end
 
+    it "7日以内に獲得したバッジがある場合はバッジ獲得祝福カードを表示すること" do
+      sign_in singing_customer
+      closed_season = FactoryBot.create(
+        :singing_ranking_season,
+        name: "2026年4月シーズン",
+        status: "closed",
+        starts_on: Date.new(2026, 4, 1),
+        ends_on: Date.new(2026, 4, 30)
+      )
+      FactoryBot.create(
+        :singing_badge,
+        customer: singing_customer,
+        singing_ranking_season: closed_season,
+        badge_type: "season_1st",
+        awarded_at: 3.days.ago
+      )
+      diagnosis = FactoryBot.create(
+        :singing_diagnosis, :completed, :ranking_participant,
+        customer: singing_customer, overall_score: 90
+      )
+
+      get singing_diagnosis_path(diagnosis)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("新しいバッジを獲得しました！")
+      expect(response.body).to include("バッジ一覧を見る")
+      expect(response.body).to include("シーズン履歴を見る")
+      expect(response.body).to include("もう一度診断する")
+    end
+
+    it "7日より前に獲得したバッジのみの場合はバッジ獲得祝福カードを表示しないこと" do
+      sign_in singing_customer
+      closed_season = FactoryBot.create(
+        :singing_ranking_season,
+        name: "2026年4月シーズン",
+        status: "closed",
+        starts_on: Date.new(2026, 4, 1),
+        ends_on: Date.new(2026, 4, 30)
+      )
+      FactoryBot.create(
+        :singing_badge,
+        customer: singing_customer,
+        singing_ranking_season: closed_season,
+        badge_type: "season_1st",
+        awarded_at: 8.days.ago
+      )
+      diagnosis = FactoryBot.create(
+        :singing_diagnosis, :completed, :ranking_participant,
+        customer: singing_customer, overall_score: 90
+      )
+
+      get singing_diagnosis_path(diagnosis)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).not_to include("新しいバッジを獲得しました！")
+    end
+
     it "バッジがない場合は「今回のあなたの実績」セクションを表示しないこと" do
       sign_in singing_customer
       diagnosis = FactoryBot.create(


### PR DESCRIPTION
7日以内に獲得したシーズンバッジがある場合、診断結果画面の「今回の実績」
セクション直前にバッジ獲得祝福カードを表示する。
バッジ一覧・シーズン履歴・再診断への導線を添え、獲得の喜びと再診断ループを強化する。
DB変更なし。@new_season_badges はメモリ上の select のみで追加クエリゼロ。