### PR TITLE
feat: singingプロフィールに称号表示を追加

### DIFF
--- a/app/assets/stylesheets/singing/users.scss
+++ b/app/assets/stylesheets/singing/users.scss
@@ -1,0 +1,67 @@
+// 称号カード（プロフィール Hero セクション）
+.singing-profile__title-card {
+  align-items: center;
+  background: linear-gradient(135deg, #fffbeb, #fef9f0);
+  border: 1px solid rgba(245, 158, 11, 0.22);
+  border-radius: 14px;
+  display: inline-flex;
+  gap: 10px;
+  margin: 8px 0 14px;
+  max-width: 100%;
+  padding: 10px 14px;
+}
+
+.singing-profile__title-icon {
+  flex-shrink: 0;
+  font-size: 22px;
+  line-height: 1;
+}
+
+.singing-profile__title-body {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.singing-profile__title-label {
+  color: #92400e;
+  font-size: 14px;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  line-height: 1.3;
+}
+
+.singing-profile__title-desc {
+  color: #b45309;
+  font-size: 12px;
+  line-height: 1.4;
+  opacity: 0.85;
+}
+
+.singing-profile__title-link {
+  color: #d97706;
+  flex-shrink: 0;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  margin-left: auto;
+  text-decoration: none;
+  white-space: nowrap;
+
+  &:hover {
+    color: #b45309;
+    text-decoration: underline;
+  }
+}
+
+@media (max-width: 600px) {
+  .singing-profile__title-card {
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+
+  .singing-profile__title-link {
+    margin-left: 0;
+  }
+}

--- a/app/controllers/singing/users_controller.rb
+++ b/app/controllers/singing/users_controller.rb
@@ -17,6 +17,7 @@ class Singing::UsersController < Singing::BaseController
     @season_badges = @user.singing_badges
                           .includes(:singing_ranking_season)
                           .order(awarded_at: :desc)
+    @profile_title = Singing::ProfileTitleService.call(@season_badges)
     @ranking_badges = Singing::RankingBadgeService.badges_for(@user)
     @growth_entries = Singing::RankingQuery.growth
     @growth_index = @growth_entries.index { |entry| entry.customer.id == @user.id }

--- a/app/services/singing/profile_title_service.rb
+++ b/app/services/singing/profile_title_service.rb
@@ -1,0 +1,80 @@
+module Singing
+  class ProfileTitleService
+    Title = Struct.new(:key, :label, :description, :icon, keyword_init: true)
+
+    TITLE_DEFINITIONS = [
+      {
+        key: :season_1st,
+        label: "今月の王者",
+        description: "シーズン1位に輝いたトップシンガー",
+        icon: "🥇"
+      },
+      {
+        key: :season_2nd,
+        label: "準優勝シンガー",
+        description: "シーズン2位に輝いた実力者",
+        icon: "🥈"
+      },
+      {
+        key: :season_top3,
+        label: "TOP3シンガー",
+        description: "シーズントップ3入りを果たした実力者",
+        icon: "🥉"
+      },
+      {
+        key: :season_top10,
+        label: "TOP10シンガー",
+        description: "シーズントップ10に入った実力者",
+        icon: "🎯"
+      },
+      {
+        key: :rapid_growth,
+        label: "急成長シンガー",
+        description: "成長ランキングTOP3に輝いた証",
+        icon: "📈"
+      },
+      {
+        key: :consecutive_participation,
+        label: "継続チャレンジャー",
+        description: "コツコツ続けることで積み上げた証",
+        icon: "🔥"
+      }
+    ].freeze
+
+    BADGE_COLLECTOR_THRESHOLD = 3
+
+    BADGE_COLLECTOR_TITLE = Title.new(
+      key: :badge_collector,
+      label: "バッジコレクター",
+      description: "複数のバッジを集めた証",
+      icon: "🎖️"
+    ).freeze
+
+    CHALLENGER_TITLE = Title.new(
+      key: :challenger,
+      label: "挑戦者",
+      description: "記録への第一歩を踏み出そう",
+      icon: "🎵"
+    ).freeze
+
+    def self.call(season_badges)
+      new(season_badges).call
+    end
+
+    def initialize(season_badges)
+      @season_badges = season_badges
+    end
+
+    def call
+      badge_types = @season_badges.map(&:badge_type)
+
+      TITLE_DEFINITIONS.each do |definition|
+        return Title.new(**definition) if badge_types.include?(definition[:key].to_s)
+      end
+
+      return BADGE_COLLECTOR_TITLE if @season_badges.size >= BADGE_COLLECTOR_THRESHOLD
+
+      CHALLENGER_TITLE
+    end
+  end
+end

--- a/app/views/singing/users/show.html.haml
+++ b/app/views/singing/users/show.html.haml
@@ -7,6 +7,12 @@
       .singing-profile__identity
         .singing-profile__eyebrow Music Growth Profile
         %h1.singing-profile__name= @user.name
+        .singing-profile__title-card
+          %span.singing-profile__title-icon= @profile_title.icon
+          .singing-profile__title-body
+            %strong.singing-profile__title-label= @profile_title.label
+            %span.singing-profile__title-desc= @profile_title.description
+          = link_to "バッジ一覧 →", singing_badges_path, class: "singing-profile__title-link"
         - if @user.singing_profile_comment.present?
           %p.singing-profile__comment= @user.singing_profile_comment
         - else

--- a/spec/requests/singing/users_spec.rb
+++ b/spec/requests/singing/users_spec.rb
@@ -262,6 +262,66 @@ RSpec.describe "Singing::Users", type: :request do
       expect(response.body).to include("TOMOKIコメント付きのシーズン振り返り")
     end
 
+    it "season_1st バッジを持つユーザーのプロフィールに「今月の王者」称号を表示すること" do
+      sign_in other_customer
+      season = create(
+        :singing_ranking_season,
+        name: "2026年4月シーズン",
+        status: "closed",
+        starts_on: Date.new(2026, 4, 1),
+        ends_on: Date.new(2026, 4, 30)
+      )
+      create(
+        :singing_badge,
+        customer: singing_customer,
+        singing_ranking_season: season,
+        badge_type: "season_1st",
+        awarded_at: 3.days.ago
+      )
+
+      get singing_user_path(singing_customer)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("今月の王者")
+      expect(response.body).to include("🥇")
+      expect(response.body).to include("singing-profile__title-card")
+    end
+
+    it "バッジがないユーザーのプロフィールに「挑戦者」称号を表示すること" do
+      sign_in other_customer
+
+      get singing_user_path(singing_customer)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("挑戦者")
+      expect(response.body).to include("🎵")
+      expect(response.body).to include("singing-profile__title-card")
+    end
+
+    it "rapid_growth バッジを持つユーザーのプロフィールに「急成長シンガー」称号を表示すること" do
+      sign_in other_customer
+      season = create(
+        :singing_ranking_season,
+        name: "2026年4月シーズン",
+        status: "closed",
+        starts_on: Date.new(2026, 4, 1),
+        ends_on: Date.new(2026, 4, 30)
+      )
+      create(
+        :singing_badge,
+        customer: singing_customer,
+        singing_ranking_season: season,
+        badge_type: "rapid_growth",
+        awarded_at: 5.days.ago
+      )
+
+      get singing_user_path(singing_customer)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("急成長シンガー")
+      expect(response.body).to include("📈")
+    end
+
     it "ランキング順位とシーズン順位と成長実績を表示すること" do
       sign_in other_customer
       now = Time.zone.now

--- a/spec/services/singing/profile_title_service_spec.rb
+++ b/spec/services/singing/profile_title_service_spec.rb
@@ -1,0 +1,131 @@
+require "rails_helper"
+
+RSpec.describe Singing::ProfileTitleService do
+  def build_badges(*badge_types)
+    badge_types.map { |type| instance_double(SingingBadge, badge_type: type.to_s) }
+  end
+
+  describe ".call" do
+    context "season_1st バッジを持つ場合" do
+      it "「今月の王者」称号を返すこと" do
+        title = described_class.call(build_badges("season_1st"))
+
+        expect(title.key).to eq(:season_1st)
+        expect(title.label).to eq("今月の王者")
+        expect(title.icon).to eq("🥇")
+        expect(title.description).to be_present
+      end
+    end
+
+    context "season_2nd バッジを持つ場合" do
+      it "「準優勝シンガー」称号を返すこと" do
+        title = described_class.call(build_badges("season_2nd"))
+
+        expect(title.key).to eq(:season_2nd)
+        expect(title.label).to eq("準優勝シンガー")
+        expect(title.icon).to eq("🥈")
+      end
+    end
+
+    context "season_top3 バッジを持つ場合" do
+      it "「TOP3シンガー」称号を返すこと" do
+        title = described_class.call(build_badges("season_top3"))
+
+        expect(title.key).to eq(:season_top3)
+        expect(title.label).to eq("TOP3シンガー")
+        expect(title.icon).to eq("🥉")
+      end
+    end
+
+    context "season_top10 バッジを持つ場合" do
+      it "「TOP10シンガー」称号を返すこと" do
+        title = described_class.call(build_badges("season_top10"))
+
+        expect(title.key).to eq(:season_top10)
+        expect(title.label).to eq("TOP10シンガー")
+        expect(title.icon).to eq("🎯")
+      end
+    end
+
+    context "rapid_growth バッジを持つ場合" do
+      it "「急成長シンガー」称号を返すこと" do
+        title = described_class.call(build_badges("rapid_growth"))
+
+        expect(title.key).to eq(:rapid_growth)
+        expect(title.label).to eq("急成長シンガー")
+        expect(title.icon).to eq("📈")
+      end
+    end
+
+    context "consecutive_participation バッジを持つ場合" do
+      it "「継続チャレンジャー」称号を返すこと" do
+        title = described_class.call(build_badges("consecutive_participation"))
+
+        expect(title.key).to eq(:consecutive_participation)
+        expect(title.label).to eq("継続チャレンジャー")
+        expect(title.icon).to eq("🔥")
+      end
+    end
+
+    context "称号対象外のバッジが3個以上ある場合" do
+      it "「バッジコレクター」称号を返すこと" do
+        badges = [
+          instance_double(SingingBadge, badge_type: "future_badge_a"),
+          instance_double(SingingBadge, badge_type: "future_badge_b"),
+          instance_double(SingingBadge, badge_type: "future_badge_c")
+        ]
+        title = described_class.call(badges)
+
+        expect(title.key).to eq(:badge_collector)
+        expect(title.label).to eq("バッジコレクター")
+        expect(title.icon).to eq("🎖️")
+      end
+    end
+
+    context "称号対象外のバッジが2個以下の場合" do
+      it "「挑戦者」称号を返すこと" do
+        badges = [
+          instance_double(SingingBadge, badge_type: "future_badge_a"),
+          instance_double(SingingBadge, badge_type: "future_badge_b")
+        ]
+        title = described_class.call(badges)
+
+        expect(title.key).to eq(:challenger)
+        expect(title.label).to eq("挑戦者")
+        expect(title.icon).to eq("🎵")
+      end
+    end
+
+    context "バッジが0件の場合" do
+      it "「挑戦者」称号を返すこと" do
+        title = described_class.call([])
+
+        expect(title.key).to eq(:challenger)
+        expect(title.label).to eq("挑戦者")
+      end
+    end
+
+    context "優先順位のテスト" do
+      it "season_1st は他のバッジより優先されること" do
+        badges = build_badges("consecutive_participation", "rapid_growth", "season_1st")
+        title = described_class.call(badges)
+
+        expect(title.key).to eq(:season_1st)
+      end
+
+      it "season_2nd は season_top3 より優先されること" do
+        badges = build_badges("season_top3", "season_2nd")
+        title = described_class.call(badges)
+
+        expect(title.key).to eq(:season_2nd)
+      end
+
+      it "rapid_growth は consecutive_participation より優先されること" do
+        badges = build_badges("consecutive_participation", "rapid_growth")
+        title = described_class.call(badges)
+
+        expect(title.key).to eq(:rapid_growth)
+      end
+    end
+  end
+end


### PR DESCRIPTION
SingingBadgeの所持状況から動的に称号を判定し、
プロフィールのHeroセクションに称号カードを表示する。