### PR TITLE
feat: 診断結果画面に次に狙えるバッジのヒントを表示

### DIFF
--- a/app/assets/stylesheets/singing/diagnoses.scss
+++ b/app/assets/stylesheets/singing/diagnoses.scss
@@ -6171,3 +6171,88 @@ $ranking-accent: #7c4dff;
   color: #777;
   margin-top: 8px;
 }
+
+// ─── 次に狙えるバッジ ────────────────────────────────────────────────────
+.singing-diagnosis__next-badges {
+  background: linear-gradient(135deg, #f0f9ff 0%, #e0f2fe 100%);
+  border: 1px solid #7dd3fc;
+  border-left: 4px solid #0ea5e9;
+  border-radius: 12px;
+  margin: 24px 0;
+  padding: 20px 22px;
+}
+
+.singing-diagnosis__next-badges-header {
+  align-items: center;
+  display: flex;
+  gap: 8px;
+  margin-bottom: 14px;
+}
+
+.singing-diagnosis__next-badges-icon {
+  font-size: 22px;
+  line-height: 1;
+}
+
+.singing-diagnosis__next-badges-title {
+  color: #0369a1;
+  font-size: 16px;
+  font-weight: 800;
+  margin: 0;
+}
+
+.singing-diagnosis__next-badges-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-bottom: 14px;
+}
+
+.singing-diagnosis__next-badge-item {
+  align-items: center;
+  background: #fff;
+  border: 1px solid #bae6fd;
+  border-radius: 10px;
+  display: flex;
+  gap: 12px;
+  padding: 12px 16px;
+}
+
+.singing-diagnosis__next-badge-emoji {
+  flex-shrink: 0;
+  font-size: 24px;
+  line-height: 1;
+}
+
+.singing-diagnosis__next-badge-body {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.singing-diagnosis__next-badge-label {
+  color: #0c4a6e;
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.singing-diagnosis__next-badge-description {
+  color: #0369a1;
+  font-size: 12px;
+  margin: 0;
+}
+
+.singing-diagnosis__next-badges-action {
+  margin-top: 6px;
+}
+
+.singing-diagnosis__next-badges-cta {
+  color: #0369a1;
+  font-size: 13px;
+  font-weight: 600;
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}

--- a/app/controllers/singing/diagnoses_controller.rb
+++ b/app/controllers/singing/diagnoses_controller.rb
@@ -43,6 +43,7 @@ class Singing::DiagnosesController < Singing::BaseController
         @ranking_rank            = Singing::RankingQuery.position_for(current_customer.id)
         @ranking_top10_threshold = top10_score_threshold
       end
+      @next_badges = Singing::NextBadgeService.call(current_customer)
     end
   end
 

--- a/app/services/singing/next_badge_service.rb
+++ b/app/services/singing/next_badge_service.rb
@@ -1,0 +1,154 @@
+module Singing
+  class NextBadgeService
+    Hint = Struct.new(:key, :label, :description, keyword_init: true)
+
+    MAX_HINTS = 3
+
+    BADGE_EMOJI = {
+      diagnoses_3:   "🎵",
+      diagnoses_10:  "🎤",
+      diagnoses_30:  "🎸",
+      first_growth:  "📈",
+      growth_plus_10: "⬆️",
+      season_top_10: "🏅",
+      season_top_1:  "🏆",
+      overall_top_10: "⭐",
+      overall_top_3:  "🌟"
+    }.freeze
+
+    def self.call(customer)
+      new(customer).call
+    end
+
+    def initialize(customer)
+      @customer = customer
+    end
+
+    def call
+      return [] unless @customer
+
+      candidates = []
+      candidates.concat(diagnosis_candidates)
+      candidates.concat(growth_candidates)
+      candidates.concat(season_rank_candidates)
+      candidates.concat(overall_rank_candidates)
+
+      candidates
+        .sort_by { |c| -c[:proximity_score] }
+        .first(MAX_HINTS)
+        .map { |c| Hint.new(key: c[:key], label: c[:label], description: c[:description]) }
+    end
+
+    private
+
+    def diagnosis_count
+      @diagnosis_count ||= SingingDiagnosis
+        .completed
+        .where(customer: @customer)
+        .where.not(overall_score: nil)
+        .count
+    end
+
+    def latest_growth_score
+      @growth_score ||= begin
+        scores = SingingDiagnosis
+          .completed
+          .where(customer: @customer)
+          .where.not(overall_score: nil)
+          .order(created_at: :desc, id: :desc)
+          .limit(2)
+          .pluck(:overall_score)
+        scores.size >= 2 ? scores[0] - scores[1] : 0
+      end
+    end
+
+    def current_season_rank
+      @season_rank ||= Singing::RankingQuery.season_position_for(@customer.id)
+    end
+
+    def current_overall_rank
+      @overall_rank ||= Singing::RankingQuery.position_for(@customer.id)
+    end
+
+    def badge_definition(key)
+      RankingBadgeService::BADGE_DEFINITIONS[key]
+    end
+
+    def build_candidate(key, description, proximity_score)
+      d = badge_definition(key)
+      { key: key, label: d[:label], description: description, proximity_score: proximity_score }
+    end
+
+    def diagnosis_candidates
+      count = diagnosis_count
+      [
+        [3,  :diagnoses_3],
+        [10, :diagnoses_10],
+        [30, :diagnoses_30]
+      ].each do |threshold, key|
+        next if count >= threshold
+        remaining  = threshold - count
+        proximity  = (count.to_f / threshold * 100).to_i
+        return [build_candidate(key, "あと#{remaining}回の診断で獲得", proximity)]
+      end
+      []
+    end
+
+    def growth_candidates
+      score = latest_growth_score
+      return [] if score >= 10
+
+      if score.positive?
+        remaining = 10 - score
+        proximity = (score.to_f / 10 * 100).to_i
+        [build_candidate(:growth_plus_10, "あと#{remaining}点の成長幅で獲得", proximity)]
+      elsif diagnosis_count >= 2
+        [build_candidate(:first_growth, "前回より高いスコアを出して獲得", 5)]
+      else
+        []
+      end
+    end
+
+    def season_rank_candidates
+      rank = current_season_rank
+      return [] unless rank
+
+      candidates = []
+
+      if rank > 10 && rank <= 20
+        gap       = rank - 10
+        proximity = ((21 - rank).to_f / 10 * 100).clamp(1, 99).to_i
+        candidates << build_candidate(:season_top_10, "あと#{gap}順位でTOP10入り", proximity)
+      end
+
+      if rank >= 2 && rank <= 5
+        gap       = rank - 1
+        proximity = ((6 - rank).to_f / 5 * 100).clamp(1, 99).to_i
+        candidates << build_candidate(:season_top_1, "あと#{gap}順位で今月の王者", proximity)
+      end
+
+      candidates
+    end
+
+    def overall_rank_candidates
+      rank = current_overall_rank
+      return [] unless rank
+
+      candidates = []
+
+      if rank > 10 && rank <= 25
+        gap       = rank - 10
+        proximity = ((26 - rank).to_f / 15 * 100).clamp(1, 99).to_i
+        candidates << build_candidate(:overall_top_10, "あと#{gap}順位で総合TOP10", proximity)
+      end
+
+      if rank > 3 && rank <= 8
+        gap       = rank - 3
+        proximity = ((9 - rank).to_f / 5 * 100).clamp(1, 99).to_i
+        candidates << build_candidate(:overall_top_3, "あと#{gap}順位で総合TOP3", proximity)
+      end
+
+      candidates
+    end
+  end
+end

--- a/app/views/singing/diagnoses/show.html.haml
+++ b/app/views/singing/diagnoses/show.html.haml
@@ -118,6 +118,22 @@
                   %span.singing-diagnosis__season-badge-new NEW
           = link_to "すべてのバッジを見る →", singing_badges_path, class: "singing-diagnosis__badges-link"
 
+      - if @next_badges.present?
+        .singing-diagnosis__next-badges
+          .singing-diagnosis__next-badges-header
+            %span.singing-diagnosis__next-badges-icon 🎯
+            %h2.singing-diagnosis__next-badges-title 次に狙えるバッジ
+          .singing-diagnosis__next-badges-list
+            - @next_badges.each do |hint|
+              - emoji = Singing::NextBadgeService::BADGE_EMOJI[hint.key] || "🎯"
+              .singing-diagnosis__next-badge-item
+                %span.singing-diagnosis__next-badge-emoji= emoji
+                .singing-diagnosis__next-badge-body
+                  %strong.singing-diagnosis__next-badge-label= hint.label
+                  %p.singing-diagnosis__next-badge-description= hint.description
+          .singing-diagnosis__next-badges-action
+            = link_to "もう一度診断する →", new_singing_diagnosis_path, class: "singing-diagnosis__next-badges-cta"
+
       .singing-diagnosis__score-guides
         %h2 スコアの見方
         %p.singing-diagnosis__score-note この診断は現時点の音声から見た目安です。絶対的な評価ではなく、練習や振り返りのヒントとしてご活用ください。

--- a/spec/services/singing/next_badge_service_spec.rb
+++ b/spec/services/singing/next_badge_service_spec.rb
@@ -1,0 +1,212 @@
+require 'rails_helper'
+
+RSpec.describe Singing::NextBadgeService, type: :service do
+  let!(:singing_domain) { Domain.find_or_create_by!(name: "singing") }
+
+  def create_singing_customer
+    customer = FactoryBot.create(:customer, domain_name: "singing")
+    CustomerDomain.find_or_create_by!(customer: customer, domain: singing_domain)
+    customer
+  end
+
+  def hint_keys(customer)
+    described_class.call(customer).map(&:key)
+  end
+
+  before do
+    allow(Singing::RankingQuery).to receive(:position_for).and_return(nil)
+    allow(Singing::RankingQuery).to receive(:season_position_for).and_return(nil)
+  end
+
+  describe ".call" do
+    context "customer が nil のとき" do
+      it "空配列を返すこと" do
+        expect(described_class.call(nil)).to eq([])
+      end
+    end
+
+    it "最大3件しか返さないこと" do
+      customer = create_singing_customer
+      FactoryBot.create(:singing_diagnosis, :completed, customer: customer, overall_score: 60, created_at: 2.days.ago)
+      FactoryBot.create(:singing_diagnosis, :completed, customer: customer, overall_score: 65, created_at: 1.day.ago)
+      allow(Singing::RankingQuery).to receive(:season_position_for).and_return(15)
+      allow(Singing::RankingQuery).to receive(:position_for).and_return(20)
+
+      expect(described_class.call(customer).size).to be <= 3
+    end
+
+    it "Hint 構造体を返すこと" do
+      customer = create_singing_customer
+      result = described_class.call(customer)
+
+      expect(result).to all(be_a(Singing::NextBadgeService::Hint))
+    end
+  end
+
+  describe "診断回数バッジ" do
+    context "診断回数が 0 のとき" do
+      it "diagnoses_3 のヒントを返すこと" do
+        customer = create_singing_customer
+        expect(hint_keys(customer)).to include(:diagnoses_3)
+      end
+
+      it "ヒントに残り回数が含まれること" do
+        customer = create_singing_customer
+        hint = described_class.call(customer).find { |h| h.key == :diagnoses_3 }
+        expect(hint.description).to include("3回")
+      end
+    end
+
+    context "診断回数が 2 のとき" do
+      it "diagnoses_3 のヒントを返し残り 1 回と表示すること" do
+        customer = create_singing_customer
+        FactoryBot.create_list(:singing_diagnosis, 2, :completed, customer: customer, overall_score: 70)
+        hint = described_class.call(customer).find { |h| h.key == :diagnoses_3 }
+        expect(hint).to be_present
+        expect(hint.description).to include("1回")
+      end
+    end
+
+    context "診断回数が 3 のとき" do
+      it "diagnoses_3 のヒントを返さず diagnoses_10 を返すこと" do
+        customer = create_singing_customer
+        FactoryBot.create_list(:singing_diagnosis, 3, :completed, customer: customer, overall_score: 70)
+        keys = hint_keys(customer)
+        expect(keys).not_to include(:diagnoses_3)
+        expect(keys).to include(:diagnoses_10)
+      end
+    end
+
+    context "診断回数が 10 のとき" do
+      it "diagnoses_30 のヒントを返すこと" do
+        customer = create_singing_customer
+        FactoryBot.create_list(:singing_diagnosis, 10, :completed, customer: customer, overall_score: 70)
+        expect(hint_keys(customer)).to include(:diagnoses_30)
+      end
+    end
+
+    context "診断回数が 30 以上のとき" do
+      it "診断回数バッジのヒントを返さないこと" do
+        customer = create_singing_customer
+        FactoryBot.create_list(:singing_diagnosis, 30, :completed, customer: customer, overall_score: 70)
+        diagnosis_keys = %i[diagnoses_3 diagnoses_10 diagnoses_30]
+        expect(hint_keys(customer) & diagnosis_keys).to be_empty
+      end
+    end
+  end
+
+  describe "成長バッジ" do
+    context "成長スコアが 1〜9 のとき" do
+      it "growth_plus_10 のヒントを返すこと" do
+        customer = create_singing_customer
+        FactoryBot.create(:singing_diagnosis, :completed, customer: customer, overall_score: 60, created_at: 2.days.ago)
+        FactoryBot.create(:singing_diagnosis, :completed, customer: customer, overall_score: 65, created_at: 1.day.ago)
+        expect(hint_keys(customer)).to include(:growth_plus_10)
+      end
+
+      it "残り点数を表示すること" do
+        customer = create_singing_customer
+        FactoryBot.create(:singing_diagnosis, :completed, customer: customer, overall_score: 60, created_at: 2.days.ago)
+        FactoryBot.create(:singing_diagnosis, :completed, customer: customer, overall_score: 65, created_at: 1.day.ago)
+        hint = described_class.call(customer).find { |h| h.key == :growth_plus_10 }
+        expect(hint.description).to include("5点")
+      end
+    end
+
+    context "成長スコアが 10 以上のとき" do
+      it "growth_plus_10 のヒントを返さないこと" do
+        customer = create_singing_customer
+        FactoryBot.create(:singing_diagnosis, :completed, customer: customer, overall_score: 60, created_at: 2.days.ago)
+        FactoryBot.create(:singing_diagnosis, :completed, customer: customer, overall_score: 71, created_at: 1.day.ago)
+        expect(hint_keys(customer)).not_to include(:growth_plus_10)
+      end
+    end
+
+    context "診断が 2 回以上あり成長スコアが 0 以下のとき" do
+      it "first_growth のヒントを返すこと" do
+        customer = create_singing_customer
+        FactoryBot.create(:singing_diagnosis, :completed, customer: customer, overall_score: 70, created_at: 2.days.ago)
+        FactoryBot.create(:singing_diagnosis, :completed, customer: customer, overall_score: 70, created_at: 1.day.ago)
+        expect(hint_keys(customer)).to include(:first_growth)
+      end
+    end
+
+    context "診断が 1 回以下で成長スコアが計算できないとき" do
+      it "first_growth のヒントを返さないこと" do
+        customer = create_singing_customer
+        FactoryBot.create(:singing_diagnosis, :completed, customer: customer, overall_score: 70)
+        expect(hint_keys(customer)).not_to include(:first_growth)
+      end
+    end
+  end
+
+  describe "シーズンランクバッジ" do
+    context "シーズン順位が 11〜20 のとき" do
+      it "season_top_10 のヒントを返すこと" do
+        customer = create_singing_customer
+        allow(Singing::RankingQuery).to receive(:season_position_for).and_return(12)
+        expect(hint_keys(customer)).to include(:season_top_10)
+      end
+
+      it "残り順位を表示すること" do
+        customer = create_singing_customer
+        allow(Singing::RankingQuery).to receive(:season_position_for).and_return(13)
+        hint = described_class.call(customer).find { |h| h.key == :season_top_10 }
+        expect(hint.description).to include("3順位")
+      end
+    end
+
+    context "シーズン順位が 2〜5 のとき" do
+      it "season_top_1 のヒントを返すこと" do
+        customer = create_singing_customer
+        allow(Singing::RankingQuery).to receive(:season_position_for).and_return(3)
+        expect(hint_keys(customer)).to include(:season_top_1)
+      end
+    end
+
+    context "シーズン順位が nil のとき" do
+      it "シーズンランク関連ヒントを返さないこと" do
+        customer = create_singing_customer
+        keys = hint_keys(customer)
+        expect(keys).not_to include(:season_top_10, :season_top_1)
+      end
+    end
+  end
+
+  describe "総合ランクバッジ" do
+    context "総合順位が 11〜25 のとき" do
+      it "overall_top_10 のヒントを返すこと" do
+        customer = create_singing_customer
+        allow(Singing::RankingQuery).to receive(:position_for).and_return(15)
+        expect(hint_keys(customer)).to include(:overall_top_10)
+      end
+    end
+
+    context "総合順位が 4〜8 のとき" do
+      it "overall_top_3 のヒントを返すこと" do
+        customer = create_singing_customer
+        allow(Singing::RankingQuery).to receive(:position_for).and_return(5)
+        expect(hint_keys(customer)).to include(:overall_top_3)
+      end
+    end
+
+    context "総合順位が nil のとき" do
+      it "総合ランク関連ヒントを返さないこと" do
+        customer = create_singing_customer
+        keys = hint_keys(customer)
+        expect(keys).not_to include(:overall_top_10, :overall_top_3)
+      end
+    end
+  end
+
+  describe "proximity_score による優先順位" do
+    it "達成に近いバッジを先に返すこと（season_top_10 rank=11 は近い）" do
+      customer = create_singing_customer
+      FactoryBot.create_list(:singing_diagnosis, 2, :completed, customer: customer, overall_score: 70)
+      allow(Singing::RankingQuery).to receive(:season_position_for).and_return(11)
+
+      hints = described_class.call(customer)
+      expect(hints.first.key).to eq(:season_top_10)
+    end
+  end
+end


### PR DESCRIPTION
Singing::NextBadgeService を新規作成し、未獲得バッジのうち
達成に近い順で最大3件のヒント（バッジ名 + 残り条件）を計算する。
診断回数・成長スコア・シーズン/総合ランクの4種類を判定対象とし、
proximity_score で優先順位を決定してユーザーに「もう一回やるか」
という行動動機を提供する。