### PR TITLE
feat: バッジ一覧ページに「次に狙えるバッジ」セクションを追加

### DIFF
--- a/app/assets/stylesheets/singing/badges.scss
+++ b/app/assets/stylesheets/singing/badges.scss
@@ -70,6 +70,76 @@
   margin-bottom: 0;
 }
 
+// 次に狙えるバッジセクション
+.singing-badges__section--next-target {
+  background: linear-gradient(145deg, #f0f4ff, #faf5ff);
+  border: 1px solid rgba(99, 102, 241, 0.15);
+}
+
+.singing-badges__next-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-bottom: 20px;
+}
+
+.singing-badges__next-item {
+  align-items: center;
+  background: #fff;
+  border: 1px solid rgba(99, 102, 241, 0.12);
+  border-radius: 12px;
+  display: flex;
+  gap: 14px;
+  padding: 14px 16px;
+}
+
+.singing-badges__next-item-emoji {
+  flex-shrink: 0;
+  font-size: 26px;
+  line-height: 1;
+}
+
+.singing-badges__next-item-body {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.singing-badges__next-item-label {
+  color: #1f2937;
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.singing-badges__next-item-description {
+  color: #6b7280;
+  font-size: 13px;
+  margin: 0;
+}
+
+.singing-badges__next-actions {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.singing-badges__next-cta {
+  font-size: 14px;
+}
+
+.singing-badges__next-ranking-link {
+  color: #4b6af0;
+  font-size: 14px;
+  font-weight: 600;
+  text-decoration: none;
+
+  &:hover {
+    color: #3b5bd9;
+    text-decoration: underline;
+  }
+}
+
 // 実績バッジグリッド
 .singing-badges__ranking-grid {
   display: grid;

--- a/app/controllers/singing/badges_controller.rb
+++ b/app/controllers/singing/badges_controller.rb
@@ -8,5 +8,6 @@ class Singing::BadgesController < Singing::BaseController
     @all_ranking_definitions = Singing::RankingBadgeService::BADGE_PRIORITY.map do |key|
       Singing::RankingBadgeService::BADGE_DEFINITIONS[key].merge(key: key)
     end
+    @next_badges = Singing::NextBadgeService.call(current_customer)
   end
 end

--- a/app/views/singing/badges/index.html.haml
+++ b/app/views/singing/badges/index.html.haml
@@ -7,6 +7,26 @@
       %h1 あなたのバッジ
       %p.singing-badges__lead 診断への取り組みで獲得した称号と、シーズンの実績バッジを確認できます。
 
+    - if @next_badges.present?
+      %section.singing-badges__section.singing-badges__section--next-target
+        .singing-badges__section-head
+          %p.singing-badges__section-kicker Next Target
+          %h2 次に狙えるバッジ
+          %p.singing-badges__section-desc あと少しで手が届くバッジです。目標にして、もう一度診断に挑戦してみましょう。
+        .singing-badges__next-list
+          - @next_badges.each do |hint|
+            - emoji = Singing::NextBadgeService::BADGE_EMOJI[hint.key] || "🎯"
+            .singing-badges__next-item
+              %span.singing-badges__next-item-emoji= emoji
+              .singing-badges__next-item-body
+                %strong.singing-badges__next-item-label= hint.label
+                %p.singing-badges__next-item-description= hint.description
+        .singing-badges__next-actions
+          = link_to new_singing_diagnosis_path, class: "btn btn-primary singing-badges__next-cta" do
+            もう一度診断する →
+          = link_to singing_rankings_path, class: "singing-badges__next-ranking-link" do
+            ランキングを見る →
+
     %section.singing-badges__section
       .singing-badges__section-head
         %p.singing-badges__section-kicker Achievement

--- a/spec/requests/singing/badges_spec.rb
+++ b/spec/requests/singing/badges_spec.rb
@@ -134,6 +134,39 @@ RSpec.describe "Singing::Badges", type: :request do
         expect(response.body).to include("今月の王者")
         expect(response.body).to include("準優勝")
       end
+
+      context "次に狙えるバッジ" do
+        it "診断未実施の場合、次に狙えるバッジセクションが表示されること" do
+          get singing_badges_path
+
+          expect(response).to have_http_status(:ok)
+          expect(response.body).to include("次に狙えるバッジ")
+          expect(response.body).to include("あと")
+          expect(response.body).to include("もう一度診断する")
+          expect(response.body).to include("ランキングを見る")
+        end
+
+        it "次に狙えるバッジのヒントにバッジ名と進捗メッセージが含まれること" do
+          get singing_badges_path
+
+          hints = Singing::NextBadgeService.call(customer)
+          expect(hints).not_to be_empty
+          hints.each do |hint|
+            expect(response.body).to include(hint.label)
+            expect(response.body).to include(hint.description)
+          end
+        end
+
+        it "NextBadgeService が空を返す場合、次に狙えるバッジセクションが表示されないこと" do
+          allow(Singing::NextBadgeService).to receive(:call).and_return([])
+
+          get singing_badges_path
+
+          expect(response).to have_http_status(:ok)
+          expect(response.body).not_to include("次に狙えるバッジ")
+          expect(response.body).not_to include("もう一度診断する")
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
NextBadgeService を流用し、バッジ一覧ページ上部に次の目標を最大3件表示。
再診断CTA・ランキング導線も合わせて設置し、継続診断を促す体験を実現。