### PR TITLE
fix: badges.scss の新規追加スタイルを .singing-badges 配下に完全スコープ

### DIFF
--- a/app/assets/stylesheets/singing/badges.scss
+++ b/app/assets/stylesheets/singing/badges.scss
@@ -70,73 +70,75 @@
   margin-bottom: 0;
 }
 
-// 次に狙えるバッジセクション
-.singing-badges__section--next-target {
-  background: linear-gradient(145deg, #f0f4ff, #faf5ff);
-  border: 1px solid rgba(99, 102, 241, 0.15);
-}
+// 次に狙えるバッジセクション（.singing-badges 配下に完全スコープ）
+.singing-badges {
+  &__section--next-target {
+    background: linear-gradient(145deg, #f0f4ff, #faf5ff);
+    border: 1px solid rgba(99, 102, 241, 0.15);
+  }
 
-.singing-badges__next-list {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  margin-bottom: 20px;
-}
+  &__next-list {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    margin-bottom: 20px;
+  }
 
-.singing-badges__next-item {
-  align-items: center;
-  background: #fff;
-  border: 1px solid rgba(99, 102, 241, 0.12);
-  border-radius: 12px;
-  display: flex;
-  gap: 14px;
-  padding: 14px 16px;
-}
+  &__next-item {
+    align-items: center;
+    background: #fff;
+    border: 1px solid rgba(99, 102, 241, 0.12);
+    border-radius: 12px;
+    display: flex;
+    gap: 14px;
+    padding: 14px 16px;
+  }
 
-.singing-badges__next-item-emoji {
-  flex-shrink: 0;
-  font-size: 26px;
-  line-height: 1;
-}
+  &__next-item-emoji {
+    flex-shrink: 0;
+    font-size: 26px;
+    line-height: 1;
+  }
 
-.singing-badges__next-item-body {
-  display: flex;
-  flex-direction: column;
-  gap: 3px;
-}
+  &__next-item-body {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+  }
 
-.singing-badges__next-item-label {
-  color: #1f2937;
-  font-size: 14px;
-  font-weight: 700;
-}
+  &__next-item-label {
+    color: #1f2937;
+    font-size: 14px;
+    font-weight: 700;
+  }
 
-.singing-badges__next-item-description {
-  color: #6b7280;
-  font-size: 13px;
-  margin: 0;
-}
+  &__next-item-description {
+    color: #6b7280;
+    font-size: 13px;
+    margin: 0;
+  }
 
-.singing-badges__next-actions {
-  align-items: center;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 12px;
-}
+  &__next-actions {
+    align-items: center;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+  }
 
-.singing-badges__next-cta {
-  font-size: 14px;
-}
+  &__next-cta {
+    font-size: 14px;
+  }
 
-.singing-badges__next-ranking-link {
-  color: #4b6af0;
-  font-size: 14px;
-  font-weight: 600;
-  text-decoration: none;
+  &__next-ranking-link {
+    color: #4b6af0;
+    font-size: 14px;
+    font-weight: 600;
+    text-decoration: none;
 
-  &:hover {
-    color: #3b5bd9;
-    text-decoration: underline;
+    &:hover {
+      color: #3b5bd9;
+      text-decoration: underline;
+    }
   }
 }
 

--- a/app/views/singing/badges/index.html.haml
+++ b/app/views/singing/badges/index.html.haml
@@ -8,7 +8,7 @@
       %p.singing-badges__lead 診断への取り組みで獲得した称号と、シーズンの実績バッジを確認できます。
 
     - if @next_badges.present?
-      %section.singing-badges__section.singing-badges__section--next-target
+      .singing-badges__section.singing-badges__section--next-target
         .singing-badges__section-head
           %p.singing-badges__section-kicker Next Target
           %h2 次に狙えるバッジ


### PR DESCRIPTION
application.scss が require_tree . で全 SCSS を単一バンドルに結合するため、 フラットなトップレベルセレクターだと他ページへの影響リスクがある。
次に狙えるバッジセクション用の新規追加クラスをすべて .singing-badges {} に
ネストし、他ページ（シーズン履歴ページ等）への意図しない波及を遮断する。

あわせて新規セクションの %section を div に統一。