### PR TITLE
feat: singing診断・バッジ・プロフィールにCTA導線を追加

### DIFF
--- a/app/assets/stylesheets/singing/badges.scss
+++ b/app/assets/stylesheets/singing/badges.scss
@@ -371,3 +371,43 @@
     text-decoration: underline;
   }
 }
+
+.singing-badges__cta-section {
+  background: linear-gradient(135deg, #f0fdf4 0%, #ecfdf5 100%);
+  border: 1px solid #bbf7d0;
+  border-radius: 14px;
+  margin: 28px 0;
+  padding: 22px 24px;
+  text-align: center;
+}
+
+.singing-badges__cta-message {
+  color: #166534;
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.6;
+  margin: 0 0 14px;
+}
+
+.singing-badges__cta-buttons {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  justify-content: center;
+}
+
+@media (max-width: 600px) {
+  .singing-badges__cta-section {
+    padding: 18px 16px;
+  }
+
+  .singing-badges__cta-buttons {
+    flex-direction: column;
+    align-items: stretch;
+
+    .btn {
+      text-align: center;
+    }
+  }
+}

--- a/app/assets/stylesheets/singing/diagnoses.scss
+++ b/app/assets/stylesheets/singing/diagnoses.scss
@@ -6371,3 +6371,50 @@ $ranking-accent: #7c4dff;
   font-weight: 700;
   white-space: nowrap;
 }
+
+.singing-diagnosis__next-badges-message {
+  color: #0369a1;
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1.6;
+  margin: 0 0 12px;
+}
+
+.singing-diagnosis__next-badges-buttons {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.singing-profile__next-badge-cta {
+  border-top: 1px solid #e2e8f0;
+  margin-top: 14px;
+  padding-top: 14px;
+}
+
+.singing-profile__next-badge-cta-message {
+  color: #374151;
+  font-size: 13px;
+  line-height: 1.6;
+  margin: 0 0 10px;
+}
+
+.singing-profile__next-badge-cta-buttons {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+@media (max-width: 600px) {
+  .singing-diagnosis__next-badges-buttons,
+  .singing-profile__next-badge-cta-buttons {
+    flex-direction: column;
+    align-items: stretch;
+
+    .btn {
+      text-align: center;
+    }
+  }
+}

--- a/app/views/singing/badges/index.html.haml
+++ b/app/views/singing/badges/index.html.haml
@@ -72,6 +72,12 @@
           %p.singing-badges__empty-note シーズンが終了すると、ランキング上位者や継続参加者にバッジが付与されます。
           = link_to "ランキングに参加する", singing_rankings_path, class: "btn btn-primary singing-badges__cta"
 
+    .singing-badges__cta-section
+      %p.singing-badges__cta-message 診断を重ねて、実績とコレクションを育てましょう。
+      .singing-badges__cta-buttons
+        = link_to "診断に挑戦する", new_singing_diagnosis_path, class: "btn btn-primary"
+        = link_to "ランキングに参加する", singing_rankings_path, class: "btn btn-secondary"
+
     .singing-badges__nav
       = link_to singing_season_histories_path, class: "singing-badges__nav-link" do
         過去のシーズン成績を見る →

--- a/app/views/singing/diagnoses/show.html.haml
+++ b/app/views/singing/diagnoses/show.html.haml
@@ -137,7 +137,11 @@
                         .singing-diagnosis__next-badge-progress-fill{ style: "width: #{hint.progress_percent.to_i.clamp(0, 100)}%" }
                       %span.singing-diagnosis__next-badge-progress-label= hint.progress_label
           .singing-diagnosis__next-badges-action
-            = link_to "もう一度診断する →", new_singing_diagnosis_path, class: "singing-diagnosis__next-badges-cta"
+            %p.singing-diagnosis__next-badges-message 次の称号まで、あと少し！もう一度診断して、今月の実績を伸ばしてみましょう。
+            .singing-diagnosis__next-badges-buttons
+              = link_to "もう一度診断する", new_singing_diagnosis_path, class: "btn btn-primary"
+              = link_to "今月のランキングを見る", singing_rankings_path, class: "btn btn-secondary"
+              = link_to "自分のプロフィールで実績を見る", singing_user_path(current_customer), class: "btn btn-secondary"
 
       .singing-diagnosis__score-guides
         %h2 スコアの見方

--- a/app/views/singing/users/show.html.haml
+++ b/app/views/singing/users/show.html.haml
@@ -75,7 +75,7 @@
             %p 最初の診断が完了すると、ここに称号が表示されます。
             - if current_customer == @user
               = link_to "診断に挑戦する", new_singing_diagnosis_path
-        - if @next_badges.present?
+        - if @next_badges.present? && current_customer == @user
           .singing-profile__next-badges
             %h3 次に狙える称号
             .singing-profile__next-badge-list
@@ -91,6 +91,12 @@
                         .singing-profile__next-badge-progress-track
                           .singing-profile__next-badge-progress-fill{ style: "width: #{hint.progress_percent.to_i.clamp(0, 100)}%" }
                         %span.singing-profile__next-badge-progress-label= hint.progress_label
+            .singing-profile__next-badge-cta
+              %p.singing-profile__next-badge-cta-message 診断を重ねて、次の称号に近づきましょう。
+              .singing-profile__next-badge-cta-buttons
+                = link_to "診断に挑戦する", new_singing_diagnosis_path, class: "btn btn-primary"
+                = link_to "ランキングを見る", singing_rankings_path, class: "btn btn-secondary"
+                = link_to "バッジ一覧を見る", singing_badges_path, class: "btn btn-secondary"
 
       %section.singing-profile__section
         .singing-profile__section-head


### PR DESCRIPTION
- 診断結果ページの「次に狙えるバッジ」直下に3点CTA（再診断・ランキング・プロフィール）を追加
- バッジ一覧ページの下部に診断促進CTAセクションを追加
- プロフィール本人表示の「次に狙える称号」下にCTA（診断・ランキング・バッジ一覧）を追加
- 他人のプロフィールには次に狙える称号・CTAを非表示にする
- スマホ対応のflexレイアウトでCTAボタンを整列