### PR TITLE
feat: シーズン履歴ページのUXと表示情報を強化

### DIFF
--- a/app/assets/stylesheets/singing/season_histories.scss
+++ b/app/assets/stylesheets/singing/season_histories.scss
@@ -212,6 +212,13 @@ $history-accent:       #f97316;
   color: $history-text-muted;
 }
 
+// ---- Result: growth variant ----
+.singing-history__result-item--growth {
+  .singing-history__result-value strong {
+    color: #059669;
+  }
+}
+
 // ---- Badges ----
 .singing-history__badges {
   display: flex;
@@ -223,8 +230,8 @@ $history-accent:       #f97316;
 .singing-history__badge {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
-  padding: 4px 12px;
+  gap: 6px;
+  padding: 6px 14px;
   border-radius: 999px;
   background: linear-gradient(135deg, #fff8e1, #fef3c7);
   border: 1px solid rgba(251, 191, 36, 0.4);
@@ -232,6 +239,15 @@ $history-accent:       #f97316;
   font-size: 13px;
   font-weight: 700;
   box-shadow: 0 2px 6px rgba(251, 191, 36, 0.2);
+}
+
+.singing-history__badge-emoji {
+  font-size: 16px;
+  line-height: 1;
+}
+
+.singing-history__badge-label {
+  line-height: 1;
 }
 
 // ---- No entry ----
@@ -355,6 +371,32 @@ $history-accent:       #f97316;
   }
 }
 
+// ---- CTA section ----
+.singing-history__cta {
+  background: linear-gradient(135deg, #fffbeb 0%, #fef3c7 100%);
+  border: 1px solid rgba(251, 191, 36, 0.35);
+  border-radius: 16px;
+  margin: 36px 0 0;
+  padding: 28px 24px;
+  text-align: center;
+}
+
+.singing-history__cta-message {
+  color: #78350f;
+  font-size: 15px;
+  font-weight: 600;
+  line-height: 1.8;
+  margin: 0 0 18px;
+}
+
+.singing-history__cta-buttons {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  justify-content: center;
+}
+
 // ---- Bottom nav ----
 .singing-history__nav {
   display: flex;
@@ -422,6 +464,19 @@ $history-accent:       #f97316;
 
   .singing-history__result-item {
     flex: 1 1 auto;
+  }
+
+  .singing-history__cta {
+    padding: 22px 16px;
+  }
+
+  .singing-history__cta-buttons {
+    flex-direction: column;
+    align-items: stretch;
+
+    .btn {
+      text-align: center;
+    }
   }
 
   .singing-history__nav {

--- a/app/controllers/singing/season_histories_controller.rb
+++ b/app/controllers/singing/season_histories_controller.rb
@@ -1,5 +1,5 @@
 class Singing::SeasonHistoriesController < Singing::BaseController
-  SeasonHistoryEntry = Struct.new(:season, :entry, :badges, keyword_init: true) do
+  SeasonHistoryEntry = Struct.new(:season, :entry, :growth_entry, :badges, :diagnosis_count, keyword_init: true) do
     def participated?
       entry.present?
     end
@@ -19,6 +19,14 @@ class Singing::SeasonHistoriesController < Singing::BaseController
     def score
       entry&.score
     end
+
+    def growth_rank
+      growth_entry&.rank
+    end
+
+    def growth_score
+      growth_entry&.score
+    end
   end
 
   def index
@@ -35,6 +43,14 @@ class Singing::SeasonHistoriesController < Singing::BaseController
                    )
                    .index_by(&:singing_ranking_season_id)
 
+    my_growth_entries = SingingSeasonRankingEntry
+                          .where(
+                            customer_id: current_customer.id,
+                            singing_ranking_season_id: season_ids,
+                            category: "growth"
+                          )
+                          .index_by(&:singing_ranking_season_id)
+
     my_badges = SingingBadge
                   .where(
                     customer_id: current_customer.id,
@@ -42,12 +58,36 @@ class Singing::SeasonHistoriesController < Singing::BaseController
                   )
                   .group_by(&:singing_ranking_season_id)
 
+    diagnosis_counts = build_diagnosis_counts(seasons)
+
     @season_histories = seasons.map do |season|
       SeasonHistoryEntry.new(
-        season: season,
-        entry:  my_entries[season.id],
-        badges: my_badges[season.id] || []
+        season:         season,
+        entry:          my_entries[season.id],
+        growth_entry:   my_growth_entries[season.id],
+        badges:         my_badges[season.id] || [],
+        diagnosis_count: diagnosis_counts[season.id] || 0
       )
+    end
+  end
+
+  private
+
+  def build_diagnosis_counts(seasons)
+    return {} if seasons.empty?
+
+    min_date = seasons.last.starts_on.beginning_of_day
+    max_date = seasons.first.ends_on.end_of_day
+
+    diagnosed_ats = SingingDiagnosis
+                      .where(customer_id: current_customer.id, status: :completed)
+                      .where(diagnosed_at: min_date..max_date)
+                      .pluck(:diagnosed_at)
+
+    seasons.each_with_object({}) do |season, h|
+      start_dt = season.starts_on.beginning_of_day
+      end_dt   = season.ends_on.end_of_day
+      h[season.id] = diagnosed_ats.count { |dt| dt >= start_dt && dt <= end_dt }
     end
   end
 end

--- a/app/views/singing/season_histories/index.html.haml
+++ b/app/views/singing/season_histories/index.html.haml
@@ -52,13 +52,25 @@
                         %strong= h.score
                       - else
                         %span.singing-history__result-pending 集計中
+                  - if h.growth_score.present?
+                    .singing-history__result-item.singing-history__result-item--growth
+                      %span.singing-history__result-label 成長幅
+                      %span.singing-history__result-value
+                        %strong= "+#{h.growth_score}"
+                        %small 点
+                  - if h.diagnosis_count > 0
+                    .singing-history__result-item
+                      %span.singing-history__result-label 参加回数
+                      %span.singing-history__result-value
+                        %strong= h.diagnosis_count
+                        %small 回
 
                 - if h.badges.any?
                   .singing-history__badges
                     - h.badges.each do |badge|
-                      %span.singing-history__badge{ title: badge.label }
-                        = badge.emoji
-                        = badge.label
+                      .singing-history__badge{ title: badge.label }
+                        %span.singing-history__badge-emoji= badge.emoji
+                        %span.singing-history__badge-label= badge.label
 
               - else
                 .singing-history__no-entry
@@ -88,6 +100,16 @@
           %br
           まずは診断を受けてみましょう。
         = link_to "歌唱・演奏診断を始める", new_singing_diagnosis_path, class: "btn btn-primary singing-history__empty-btn"
+
+    .singing-history__cta
+      %p.singing-history__cta-message
+        過去の積み重ねが、次の称号につながります。
+        %br
+        今月も診断して、新しい実績を増やしましょう。
+      .singing-history__cta-buttons
+        = link_to "もう一度診断する", new_singing_diagnosis_path, class: "btn btn-primary"
+        = link_to "今月のランキングを見る", singing_rankings_path, class: "btn btn-secondary"
+        = link_to "バッジ一覧を見る", singing_badges_path, class: "btn btn-secondary"
 
     .singing-history__nav
       = link_to singing_badges_path, class: "singing-history__nav-link" do

--- a/spec/requests/singing/season_histories_spec.rb
+++ b/spec/requests/singing/season_histories_spec.rb
@@ -201,6 +201,83 @@ RSpec.describe "Singing::SeasonHistories", type: :request do
           expect(response.body).to include(singing_rankings_path)
         end
       end
+
+      context "成長エントリが存在する場合" do
+        let!(:closed_season) do
+          create(:singing_ranking_season, :closed, name: "2026年4月シーズン")
+        end
+        let!(:entry) do
+          create(:singing_season_ranking_entry,
+                 singing_ranking_season: closed_season,
+                 customer: customer,
+                 category: "overall",
+                 rank: 3,
+                 score: 80)
+        end
+        let!(:growth_entry) do
+          create(:singing_season_ranking_entry,
+                 singing_ranking_season: closed_season,
+                 customer: customer,
+                 category: "growth",
+                 rank: 2,
+                 score: 12)
+        end
+
+        it "成長幅スコアが表示されること" do
+          get singing_season_histories_path
+
+          expect(response).to have_http_status(:ok)
+          expect(response.body).to include("成長幅")
+          expect(response.body).to include("+12")
+        end
+      end
+
+      context "参加回数が1回以上ある場合" do
+        let!(:active_season) do
+          create(:singing_ranking_season, :current, name: "2026年5月シーズン")
+        end
+        let!(:entry) do
+          create(:singing_season_ranking_entry,
+                 singing_ranking_season: active_season,
+                 customer: customer,
+                 category: "overall",
+                 rank: 5,
+                 score: 75)
+        end
+
+        before do
+          create(:singing_diagnosis, :completed, :ranking_participant,
+                 customer: customer,
+                 diagnosed_at: active_season.starts_on + 1.day)
+          create(:singing_diagnosis, :completed, :ranking_participant,
+                 customer: customer,
+                 diagnosed_at: active_season.starts_on + 3.days)
+        end
+
+        it "参加回数が表示されること" do
+          get singing_season_histories_path
+
+          expect(response).to have_http_status(:ok)
+          expect(response.body).to include("参加回数")
+        end
+      end
+
+      context "CTAセクション" do
+        it "今月の積み重ねを促すCTAメッセージが表示されること" do
+          get singing_season_histories_path
+
+          expect(response.body).to include("過去の積み重ねが、次の称号につながります")
+          expect(response.body).to include("今月も診断して")
+        end
+
+        it "診断・ランキング・バッジへのCTAリンクが含まれること" do
+          get singing_season_histories_path
+
+          expect(response.body).to include(new_singing_diagnosis_path)
+          expect(response.body).to include(singing_rankings_path)
+          expect(response.body).to include(singing_badges_path)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
- コントローラに成長エントリ・診断回数を追加取得（2クエリ増、N+1なし）
- 参加済みカードに「成長幅」「参加回数」を追加表示
- バッジ表示をアイコン+テキスト分離の構造に変更
- ページ下部に「称号への積み重ね」CTAセクションを追加
- スマホ時のCTAを縦並び全幅ボタンに対応
- 新機能に対応するrspecを4ケース追加