### PR TITLE
fix: ランキング未参加でも診断実績があれば空状態メッセージを改善する

### DIFF
--- a/app/controllers/singing/ranking_seasons_controller.rb
+++ b/app/controllers/singing/ranking_seasons_controller.rb
@@ -10,5 +10,9 @@ class Singing::RankingSeasonsController < Singing::BaseController
                                   .includes(:customer, :singing_diagnosis)
                                   .by_rank
                                   .group_by(&:category)
+    @my_diagnosis_count = SingingDiagnosis
+                            .where(customer_id: current_customer.id, status: :completed)
+                            .where(diagnosed_at: @season.starts_on.beginning_of_day..@season.ends_on.end_of_day)
+                            .count
   end
 end

--- a/app/views/singing/ranking_seasons/show.html.haml
+++ b/app/views/singing/ranking_seasons/show.html.haml
@@ -18,11 +18,28 @@
     - if @entries_by_category.empty?
       .singing-season__empty
         %p.singing-season__empty-icon ☆
-        %p.singing-season__empty-text
-          このシーズンのエントリーはまだありません。
-          %br
-          - if @season.status == "active"
-            診断でランキング参加をONにして、最初のエントリーを目指しましょう！
+        - if @my_diagnosis_count > 0
+          %p.singing-season__empty-text
+            - if @season.status == "active"
+              診断実績はありますが、ランキングにはまだ参加していません。
+              %br
+              ランキング参加をONにして診断すると、このシーズンにエントリーされます。
+            - else
+              このシーズンでは診断しましたが、ランキングへの参加なしでした。
+          %p.singing-season__empty-diagnosis-count
+            このシーズンの診断回数：
+            %strong= @my_diagnosis_count
+            回
+          .singing-season__empty-actions
+            - if @season.status == "active"
+              = link_to "ランキング参加して診断する", new_singing_diagnosis_path, class: "btn btn-primary"
+            = link_to "シーズン履歴を見る", singing_season_histories_path, class: "btn btn-secondary"
+        - else
+          %p.singing-season__empty-text
+            このシーズンのエントリーはまだありません。
+            %br
+            - if @season.status == "active"
+              診断でランキング参加をONにして、最初のエントリーを目指しましょう！
 
     - else
       - @entries_by_category.each do |category, entries|

--- a/spec/requests/singing/ranking_seasons_spec.rb
+++ b/spec/requests/singing/ranking_seasons_spec.rb
@@ -182,5 +182,83 @@ RSpec.describe "Singing::RankingSeasons", type: :request do
         }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
+
+    context "ランキング未参加でも診断実績がある場合（開催中シーズン）" do
+      let!(:season) { FactoryBot.create(:singing_ranking_season, :current, name: "2026年5月シーズン") }
+
+      before do
+        FactoryBot.create(:singing_diagnosis, :completed,
+                          customer: singing_customer,
+                          ranking_opt_in: false,
+                          diagnosed_at: season.starts_on + 1.day)
+        FactoryBot.create(:singing_diagnosis, :completed,
+                          customer: singing_customer,
+                          ranking_opt_in: false,
+                          diagnosed_at: season.starts_on + 3.days)
+      end
+
+      it "「診断実績はありますが」メッセージが表示されること" do
+        get singing_ranking_season_path(season)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("診断実績はありますが、ランキングにはまだ参加していません")
+      end
+
+      it "「このシーズンのエントリーはまだありません」が表示されないこと" do
+        get singing_ranking_season_path(season)
+
+        expect(response.body).not_to include("このシーズンのエントリーはまだありません")
+      end
+
+      it "このシーズンの診断回数が表示されること" do
+        get singing_ranking_season_path(season)
+
+        expect(response.body).to include("このシーズンの診断回数")
+        expect(response.body).to include("2")
+      end
+
+      it "「ランキング参加して診断する」CTAが表示されること" do
+        get singing_ranking_season_path(season)
+
+        expect(response.body).to include("ランキング参加して診断する")
+      end
+
+      it "「シーズン履歴を見る」リンクが表示されること" do
+        get singing_ranking_season_path(season)
+
+        expect(response.body).to include("シーズン履歴を見る")
+        expect(response.body).to include(singing_season_histories_path)
+      end
+    end
+
+    context "ランキング未参加でも診断実績がある場合（終了済みシーズン）" do
+      let!(:season) { FactoryBot.create(:singing_ranking_season, :closed, name: "2026年4月シーズン") }
+
+      before do
+        FactoryBot.create(:singing_diagnosis, :completed,
+                          customer: singing_customer,
+                          ranking_opt_in: false,
+                          diagnosed_at: season.starts_on + 1.day)
+      end
+
+      it "「このシーズンでは診断しましたが」メッセージが表示されること" do
+        get singing_ranking_season_path(season)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("このシーズンでは診断しましたが、ランキングへの参加なしでした")
+      end
+
+      it "「ランキング参加して診断する」CTAは表示されないこと（終了済み）" do
+        get singing_ranking_season_path(season)
+
+        expect(response.body).not_to include("ランキング参加して診断する")
+      end
+
+      it "「シーズン履歴を見る」リンクが表示されること" do
+        get singing_ranking_season_path(season)
+
+        expect(response.body).to include("シーズン履歴を見る")
+      end
+    end
   end
 end


### PR DESCRIPTION
showアクションにmy_diagnosis_countを追加し、エントリーがない場合でも
診断実績がある場合は「診断実績はありますが未参加」と診断回数を表示する。
開催中は「ランキング参加して診断する」CTAを表示し、終了済みは履歴リンクのみ表示する。