### PR TITLE
feat: 高校軽音部向けLearning機能を改善する（Phase1-5）

### DIFF
--- a/app/controllers/learning/student_portals_controller.rb
+++ b/app/controllers/learning/student_portals_controller.rb
@@ -3,8 +3,11 @@ class Learning::StudentPortalsController < ApplicationController
 
   def show
     @student = LearningStudent
-      .includes(:learning_school_group, :learning_student_parts, :learning_student_trainings, :learning_progress_logs)
+      .includes(:learning_school_group, :learning_student_parts,
+                :learning_student_trainings, :learning_progress_logs)
       .find_by!(public_access_token: params[:token])
+
+    LearningPortalAccess.record_access!(@student)
 
     trainings = @student.learning_student_trainings.ordered.to_a
     recent_logs = @student.learning_progress_logs.recent_first.limit(10)
@@ -19,5 +22,15 @@ class Learning::StudentPortalsController < ApplicationController
     }
     @current_trainings = trainings.first(8)
     @recent_logs = recent_logs
+    @current_streak  = LearningPortalAccess.current_streak(@student)
+    @effort_points   = @student.total_effort_points
+    @show_tutorial   = !@student.tutorial_completed?
+    @ranking         = @student.rank_within_group
+  end
+
+  def complete_tutorial
+    student = LearningStudent.find_by!(public_access_token: params[:token])
+    student.update!(tutorial_completed: true)
+    head :ok
   end
 end

--- a/app/controllers/learning/teacher_dashboards_controller.rb
+++ b/app/controllers/learning/teacher_dashboards_controller.rb
@@ -1,0 +1,20 @@
+class Learning::TeacherDashboardsController < Learning::BaseController
+  def show
+    @school_groups = current_customer.learning_school_groups.ordered
+    @students = current_customer.learning_students
+                                .includes(:learning_school_group,
+                                          :learning_student_trainings,
+                                          :learning_progress_logs)
+                                .active
+                                .ordered
+    @monthly_report = LearningMonthlyReport.for_month(current_customer)
+  end
+
+  def export_csv
+    csv = Learning::CsvExporter.students_progress(current_customer)
+    filename = "students_progress_#{Date.current.strftime('%Y%m%d')}.csv"
+    send_data "﻿#{csv}", filename: filename,
+                              type: "text/csv; charset=UTF-8",
+                              disposition: "attachment"
+  end
+end

--- a/app/javascript/packs/learning_portal_tutorial.js
+++ b/app/javascript/packs/learning_portal_tutorial.js
@@ -1,0 +1,29 @@
+document.addEventListener("DOMContentLoaded", () => {
+  const tutorial = document.getElementById("portal-tutorial");
+  if (!tutorial) return;
+
+  const completeUrl = tutorial.dataset.completeUrl;
+  let currentStep = 1;
+
+  const showStep = (step) => {
+    tutorial.querySelectorAll("[data-step]").forEach((el) => {
+      el.style.display = el.dataset.step === String(step) ? "" : "none";
+    });
+  };
+
+  tutorial.querySelector("[data-action='next']")?.addEventListener("click", () => {
+    currentStep++;
+    showStep(currentStep);
+  });
+
+  tutorial.querySelector("[data-action='complete']")?.addEventListener("click", () => {
+    fetch(completeUrl, {
+      method: "POST",
+      headers: {
+        "X-CSRF-Token": document.querySelector('meta[name="csrf-token"]')?.content,
+      },
+    }).finally(() => {
+      tutorial.remove();
+    });
+  });
+});

--- a/app/jobs/learning/monthly_report_job.rb
+++ b/app/jobs/learning/monthly_report_job.rb
@@ -1,0 +1,15 @@
+module Learning
+  class MonthlyReportJob < ApplicationJob
+    queue_as :default
+
+    def perform(month_str = nil)
+      month = month_str ? Date.parse(month_str).beginning_of_month : Date.current.prev_month.beginning_of_month
+
+      Customer.joins(:learning_students).distinct.find_each do |customer|
+        Learning::MonthlyReportGenerator.call(customer, month)
+      rescue => e
+        Rails.logger.error "[Learning::MonthlyReportJob] customer_id=#{customer.id} error=#{e.message}"
+      end
+    end
+  end
+end

--- a/app/jobs/learning/weekly_reminder_job.rb
+++ b/app/jobs/learning/weekly_reminder_job.rb
@@ -1,0 +1,19 @@
+module Learning
+  class WeeklyReminderJob < ApplicationJob
+    queue_as :default
+
+    def perform
+      Customer.joins(:learning_students)
+              .merge(LearningStudent.active)
+              .distinct.find_each do |teacher|
+        teacher.learning_students.active.each do |student|
+          next unless student.email.present?
+
+          LearningMailer.student_portal_mail(teacher, student).deliver_later
+        rescue => e
+          Rails.logger.error "[Learning::WeeklyReminderJob] student_id=#{student.id} error=#{e.message}"
+        end
+      end
+    end
+  end
+end

--- a/app/models/learning_effort_point.rb
+++ b/app/models/learning_effort_point.rb
@@ -1,0 +1,19 @@
+class LearningEffortPoint < ApplicationRecord
+  POINT_TYPES = {
+    "progress_log"      => { points: 5,  label: "練習記録" },
+    "training_achieved" => { points: 20, label: "課題達成" },
+    "streak_bonus"      => { points: 10, label: "継続ボーナス" },
+    "manual"            => { points: 0,  label: "手動付与" }
+  }.freeze
+
+  belongs_to :customer
+  belongs_to :learning_student
+
+  validates :point_type, presence: true, inclusion: { in: POINT_TYPES.keys }
+  validates :points, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+  validates :earned_on, presence: true
+
+  scope :this_month, -> { where(earned_on: Date.current.beginning_of_month..) }
+  scope :this_week,  -> { where(earned_on: Date.current.beginning_of_week..) }
+  scope :recent_first, -> { order(earned_on: :desc, created_at: :desc) }
+end

--- a/app/models/learning_monthly_report.rb
+++ b/app/models/learning_monthly_report.rb
@@ -1,0 +1,15 @@
+class LearningMonthlyReport < ApplicationRecord
+  belongs_to :customer
+
+  validates :report_month, presence: true, uniqueness: { scope: :customer_id }
+
+  scope :recent_first, -> { order(report_month: :desc) }
+
+  def self.for_month(customer, month = Date.current.prev_month.beginning_of_month)
+    find_or_initialize_by(customer: customer, report_month: month)
+  end
+
+  def month_label
+    report_month.strftime("%Y年%-m月")
+  end
+end

--- a/app/models/learning_portal_access.rb
+++ b/app/models/learning_portal_access.rb
@@ -1,0 +1,41 @@
+class LearningPortalAccess < ApplicationRecord
+  belongs_to :learning_student
+
+  validates :accessed_on, presence: true,
+                           uniqueness: { scope: :learning_student_id }
+
+  def self.record_access!(student)
+    today = Date.current
+    return if exists?(learning_student: student, accessed_on: today)
+
+    yesterday_record = find_by(learning_student: student, accessed_on: today - 1)
+    streak = yesterday_record ? yesterday_record.streak_count + 1 : 1
+
+    create!(learning_student: student, accessed_on: today, streak_count: streak)
+    award_streak_bonus!(student, streak)
+  end
+
+  def self.current_streak(student)
+    find_by(learning_student: student, accessed_on: Date.current)&.streak_count || 0
+  end
+
+  class << self
+    private
+
+    def award_streak_bonus!(student, streak)
+      # 7日の倍数でボーナス付与
+      return unless streak > 1 && (streak % 7).zero?
+
+      pts = LearningEffortPoint::POINT_TYPES["streak_bonus"][:points]
+      LearningEffortPoint.create!(
+        customer_id: student.customer_id,
+        learning_student: student,
+        point_type: "streak_bonus",
+        points: pts,
+        description: "#{streak}日連続アクセスボーナス",
+        earned_on: Date.current
+      )
+      student.increment!(:total_effort_points, pts)
+    end
+  end
+end

--- a/app/models/learning_progress_log.rb
+++ b/app/models/learning_progress_log.rb
@@ -10,6 +10,7 @@ class LearningProgressLog < ApplicationRecord
   validates :comment, length: { maximum: 1000 }
 
   before_validation :copy_training_fields, if: -> { learning_student_training.present? && training_title.blank? }
+  after_create :award_progress_log_point
 
   scope :recent_first, -> { order(practiced_on: :desc, created_at: :desc) }
   scope :with_filters, lambda { |params|
@@ -32,5 +33,26 @@ class LearningProgressLog < ApplicationRecord
   def copy_training_fields
     self.part = learning_student_training.part
     self.training_title = learning_student_training.title
+  end
+
+  def award_progress_log_point
+    # 同日の同じ課題への重複付与は防止する
+    already_awarded = LearningEffortPoint.exists?(
+      learning_student_id: learning_student_id,
+      point_type: "progress_log",
+      earned_on: practiced_on
+    )
+    return if already_awarded
+
+    LearningEffortPoint.create!(
+      customer_id: customer_id,
+      learning_student_id: learning_student_id,
+      point_type: "progress_log",
+      points: LearningEffortPoint::POINT_TYPES["progress_log"][:points],
+      description: "練習記録: #{training_title}",
+      earned_on: practiced_on
+    )
+    learning_student.increment!(:total_effort_points,
+                                LearningEffortPoint::POINT_TYPES["progress_log"][:points])
   end
 end

--- a/app/models/learning_school_group.rb
+++ b/app/models/learning_school_group.rb
@@ -4,6 +4,9 @@ class LearningSchoolGroup < ApplicationRecord
 
   validates :name, presence: true, length: { maximum: 100 }, uniqueness: { scope: :customer_id }
   validates :memo, length: { maximum: 1000 }
+  validates :school_code, length: { maximum: 20 }, allow_blank: true,
+                          uniqueness: { scope: :customer_id, allow_blank: true }
+  validates :advisor_name, length: { maximum: 100 }, allow_blank: true
 
   scope :ordered, -> { order(:name) }
   scope :with_filters, lambda { |params|

--- a/app/models/learning_student.rb
+++ b/app/models/learning_student.rb
@@ -6,8 +6,11 @@ class LearningStudent < ApplicationRecord
   has_many :learning_progress_logs, dependent: :destroy
   has_many :learning_band_memberships, dependent: :destroy
   has_many :learning_bands, through: :learning_band_memberships
+  has_many :learning_effort_points, dependent: :destroy
+  has_many :learning_portal_accesses, dependent: :destroy
 
   validates :name, presence: true, length: { maximum: 50 }
+  validates :nickname, length: { maximum: 30 }, allow_blank: true
   validates :main_part, presence: true, inclusion: { in: LearningCatalog::PARTS.keys }
   validates :status, presence: true, inclusion: { in: LearningCatalog::STUDENT_STATUSES.keys }
   validates :grade, length: { maximum: 50 }
@@ -15,6 +18,7 @@ class LearningStudent < ApplicationRecord
     format: { with: URI::MailTo::EMAIL_REGEXP, message: "はメールアドレス形式で入力してください" }
 
   scope :ordered, -> { order(:name) }
+  scope :active, -> { where(status: "active") }
   scope :with_filters, lambda { |params|
     scope = all
     scope = scope.where(status: params[:status]) if params[:status].present?
@@ -28,6 +32,28 @@ class LearningStudent < ApplicationRecord
   }
 
   before_validation :ensure_public_access_token
+
+  def display_name
+    nickname.present? ? nickname : name
+  end
+
+  def achievement_rate
+    total = learning_student_trainings.count
+    return 0.0 if total.zero?
+
+    achieved = learning_student_trainings.where(status: "achieved").count
+    (achieved.to_f / total * 100).round(1)
+  end
+
+  def rank_within_group
+    return nil unless learning_school_group
+
+    siblings = learning_school_group.learning_students.active
+                                    .order(total_effort_points: :desc)
+                                    .pluck(:id)
+    pos = siblings.index(id)
+    pos ? pos + 1 : nil
+  end
 
   def displayed_parts
     codes = learning_student_parts.order(primary: :desc, part: :asc).pluck(:part)

--- a/app/models/learning_student_training.rb
+++ b/app/models/learning_student_training.rb
@@ -14,6 +14,7 @@ class LearningStudentTraining < ApplicationRecord
 
   before_validation :copy_master_fields, if: -> { learning_training_master.present? && title.blank? }
   before_validation :set_default_position, on: :create
+  after_update :award_achievement_point, if: :saved_change_to_status?
 
   scope :ordered, -> { order(:position, :created_at) }
   scope :with_filters, lambda { |params|
@@ -49,5 +50,28 @@ class LearningStudentTraining < ApplicationRecord
 
     max_position = learning_student&.learning_student_trainings&.maximum(:position).to_i
     self.position = max_position + 1
+  end
+
+  def award_achievement_point
+    return unless status == "achieved"
+
+    # 同じ課題での二重付与防止
+    already_awarded = LearningEffortPoint.exists?(
+      learning_student_id: learning_student_id,
+      point_type: "training_achieved",
+      description: "課題達成: #{title}"
+    )
+    return if already_awarded
+
+    LearningEffortPoint.create!(
+      customer_id: customer_id,
+      learning_student_id: learning_student_id,
+      point_type: "training_achieved",
+      points: LearningEffortPoint::POINT_TYPES["training_achieved"][:points],
+      description: "課題達成: #{title}",
+      earned_on: Date.current
+    )
+    learning_student.increment!(:total_effort_points,
+                                LearningEffortPoint::POINT_TYPES["training_achieved"][:points])
   end
 end

--- a/app/services/learning/csv_exporter.rb
+++ b/app/services/learning/csv_exporter.rb
@@ -1,0 +1,38 @@
+require "csv"
+
+module Learning
+  class CsvExporter
+    def self.students_progress(customer)
+      students = customer.learning_students
+                         .includes(:learning_school_group,
+                                   :learning_student_trainings,
+                                   :learning_effort_points)
+                         .active
+                         .ordered
+
+      CSV.generate(headers: true, encoding: "UTF-8") do |csv|
+        csv << ["名前", "ニックネーム", "パート", "学年", "グループ",
+                "課題数", "達成数", "達成率(%)", "努力ポイント", "最終練習日"]
+
+        students.each do |student|
+          trainings = student.learning_student_trainings
+          achieved  = trainings.where(status: "achieved").count
+          last_log  = student.learning_progress_logs.maximum(:practiced_on)
+
+          csv << [
+            student.name,
+            student.nickname,
+            student.main_part,
+            student.grade,
+            student.learning_school_group&.name,
+            trainings.count,
+            achieved,
+            student.achievement_rate,
+            student.total_effort_points,
+            last_log
+          ]
+        end
+      end
+    end
+  end
+end

--- a/app/services/learning/monthly_report_generator.rb
+++ b/app/services/learning/monthly_report_generator.rb
@@ -1,0 +1,46 @@
+module Learning
+  class MonthlyReportGenerator
+    def self.call(customer, month = Date.current.prev_month.beginning_of_month)
+      new(customer, month).generate
+    end
+
+    def initialize(customer, month)
+      @customer = customer
+      @month    = month
+      @range    = month..(month.end_of_month)
+    end
+
+    def generate
+      report = LearningMonthlyReport.for_month(@customer, @month)
+      report.assign_attributes(
+        total_students:           active_students.count,
+        total_progress_logs:      logs_in_month.count,
+        total_achieved_trainings: trainings_achieved_in_month.count,
+        avg_achievement_rate:     avg_rate
+      )
+      report.save!
+      report
+    end
+
+    private
+
+    def active_students
+      @active_students ||= @customer.learning_students.active
+    end
+
+    def logs_in_month
+      @customer.learning_progress_logs.where(practiced_on: @range)
+    end
+
+    def trainings_achieved_in_month
+      @customer.learning_student_trainings.where(status: "achieved", updated_at: @range)
+    end
+
+    def avg_rate
+      return 0.0 if active_students.empty?
+
+      rates = active_students.map(&:achievement_rate)
+      (rates.sum / rates.size).round(2)
+    end
+  end
+end

--- a/app/views/learning/student_portals/show.html.haml
+++ b/app/views/learning/student_portals/show.html.haml
@@ -1,9 +1,31 @@
+- if @show_tutorial
+  #portal-tutorial.portal-tutorial{ data: { complete_url: learning_student_portal_complete_tutorial_path(@student.public_access_token) } }
+    .portal-tutorial__backdrop
+    .portal-tutorial__card
+      .portal-tutorial__step{ data: { step: "1" } }
+        %h2.portal-tutorial__title ようこそ！
+        %p ここはあなただけの練習ポータルです。
+        %p 課題をこなすたびに
+          %strong 努力ポイント
+          がもらえます。
+        %button.learning-button.portal-tutorial__next{ data: { action: "next" } } 次へ
+      .portal-tutorial__step{ data: { step: "2" }, style: "display:none" }
+        %h2.portal-tutorial__title ポイントをためよう
+        %p
+          %strong 練習記録をつけると5PT
+        %p
+          %strong 課題を達成すると20PT
+        %p 毎週連続でアクセスすると
+          %strong ボーナスポイント
+          ももらえます！
+        %button.learning-button.portal-tutorial__done{ data: { action: "complete" } } はじめる！
+
 .learning-shell.learning-shell--portal
   .learning-main.learning-main--portal
     .learning-topbar
       .learning-topbar__text
         %p.learning-topbar__eyebrow Student Page
-        %h1= "#{@student.name} さんのトレーニング"
+        %h1= "#{@student.display_name} さんのトレーニング"
         %p.learning-topbar__subtitle
           = [@student.learning_school_group&.name, @student.grade.presence].compact.join(" / ").presence || "今週の目標と進捗を確認できます。"
 
@@ -18,6 +40,15 @@
           %span.learning-stat-card__label 達成数
           %strong.learning-stat-card__value= @summary[:achievement_count]
           %p.learning-stat-card__sub= "全 #{@summary[:total_count]} 件"
+        .learning-stat-card
+          %span.learning-stat-card__label 努力ポイント
+          %strong.learning-stat-card__value= "#{@effort_points}PT"
+          - if @ranking
+            %p.learning-stat-card__sub= "グループ #{@ranking}位"
+        .learning-stat-card
+          %span.learning-stat-card__label 連続アクセス
+          %strong.learning-stat-card__value= "#{@current_streak}日"
+          %p.learning-stat-card__sub= @current_streak >= 7 ? "すごい！続けてます" : "毎日チェックしよう"
         .learning-stat-card
           %span.learning-stat-card__label 今週の目標
           %strong.learning-stat-card__value= @summary[:weekly_goal].presence || "確認しよう"

--- a/app/views/learning/teacher_dashboards/show.html.haml
+++ b/app/views/learning/teacher_dashboards/show.html.haml
@@ -1,0 +1,75 @@
+= render "learning/shared/page", title: "顧問ダッシュボード", subtitle: "生徒の進捗・努力ポイントを一覧確認できます。" do
+
+  -# 月次サマリー
+  - report = @monthly_report
+  .learning-stat-grid
+    .learning-stat-card
+      %span.learning-stat-card__label 在籍生徒数
+      %strong.learning-stat-card__value= @students.count
+      %p.learning-stat-card__sub アクティブな生徒
+    .learning-stat-card
+      %span.learning-stat-card__label 今月の練習記録
+      %strong.learning-stat-card__value= report.persisted? ? report.total_progress_logs : "-"
+      %p.learning-stat-card__sub= report.persisted? ? report.month_label : "未集計"
+    .learning-stat-card
+      %span.learning-stat-card__label 平均達成率
+      %strong.learning-stat-card__value= report.persisted? ? "#{report.avg_achievement_rate}%" : "-"
+      %p.learning-stat-card__sub 今月の全体平均
+    .learning-stat-card
+      %span.learning-stat-card__label 今月の課題達成
+      %strong.learning-stat-card__value= report.persisted? ? report.total_achieved_trainings : "-"
+      %p.learning-stat-card__sub ⭐ に更新された件数
+
+  -# グループフィルタ + CSVエクスポート
+  .learning-section
+    .learning-section__header
+      %h2 生徒一覧
+      = link_to "CSVエクスポート",
+                export_csv_learning_teacher_dashboard_path,
+                class: "learning-button learning-button--ghost",
+                data: { turbo: false }
+
+    - if @school_groups.any?
+      .learning-filter-form
+        %span.learning-filter-form__label グループで絞り込む:
+        = link_to "全員",
+                  learning_teacher_dashboard_path,
+                  class: "learning-button #{'learning-button--ghost' unless params[:group_id].nil?}"
+        - @school_groups.each do |group|
+          = link_to group.name,
+                    learning_teacher_dashboard_path(group_id: group.id),
+                    class: "learning-button #{'learning-button--ghost' unless params[:group_id].to_s == group.id.to_s}"
+
+    .learning-table-wrap
+      %table.learning-table
+        %thead
+          %tr
+            %th 名前
+            %th ニックネーム
+            %th パート
+            %th 学年
+            %th グループ
+            %th.text-right 達成率
+            %th.text-right 努力PT
+            %th 最終練習日
+            %th
+        %tbody
+          - @students.each do |student|
+            - last_log = student.learning_progress_logs.maximum(:practiced_on)
+            %tr
+              %td
+                = link_to student.name, learning_student_path(student)
+              %td.text-muted= student.nickname.presence || "-"
+              %td= learning_part_label(student.main_part)
+              %td= student.grade.presence || "-"
+              %td= student.learning_school_group&.name || "未所属"
+              %td.text-right
+                .learning-progress.learning-progress--compact{ style: learning_progress_style(student.main_part) }
+                  .learning-progress__bar{ style: "width: #{learning_progress_bar_width(student.achievement_rate)}%" }
+                %small= "#{student.achievement_rate}%"
+              %td.text-right
+                %strong= student.total_effort_points
+                %small PT
+              %td= last_log ? l(last_log, format: :short) : "-"
+              %td
+                = link_to "詳細", learning_student_path(student), class: "learning-button learning-button--ghost learning-button--sm"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -215,7 +215,11 @@ Rails.application.routes.draw do
     post "join", to: "joins#create"
 
     resource :dashboard, only: :show, controller: :dashboards
+    resource :teacher_dashboard, only: :show, controller: :teacher_dashboards do
+      get :export_csv, on: :collection
+    end
     get "portal/:token", to: "student_portals#show", as: :student_portal
+    post "portal/:token/complete_tutorial", to: "student_portals#complete_tutorial", as: :student_portal_complete_tutorial
     resources :school_groups
     resources :students do
       member do

--- a/db/migrate/20260508000001_add_nickname_and_points_to_learning_students.rb
+++ b/db/migrate/20260508000001_add_nickname_and_points_to_learning_students.rb
@@ -1,0 +1,7 @@
+class AddNicknameAndPointsToLearningStudents < ActiveRecord::Migration[6.1]
+  def change
+    add_column :learning_students, :nickname, :string, limit: 30
+    add_column :learning_students, :tutorial_completed, :boolean, default: false, null: false
+    add_column :learning_students, :total_effort_points, :integer, default: 0, null: false
+  end
+end

--- a/db/migrate/20260508000002_add_school_code_to_learning_school_groups.rb
+++ b/db/migrate/20260508000002_add_school_code_to_learning_school_groups.rb
@@ -1,0 +1,9 @@
+class AddSchoolCodeToLearningSchoolGroups < ActiveRecord::Migration[6.1]
+  def change
+    add_column :learning_school_groups, :school_code, :string, limit: 20
+    add_column :learning_school_groups, :advisor_name, :string, limit: 100
+    add_index :learning_school_groups, [:customer_id, :school_code],
+              unique: true, name: "index_learning_school_groups_on_customer_and_code",
+              where: "school_code IS NOT NULL"
+  end
+end

--- a/db/migrate/20260508000003_create_learning_effort_points.rb
+++ b/db/migrate/20260508000003_create_learning_effort_points.rb
@@ -1,0 +1,18 @@
+class CreateLearningEffortPoints < ActiveRecord::Migration[6.1]
+  def change
+    create_table :learning_effort_points do |t|
+      t.references :customer, null: false, foreign_key: true
+      t.references :learning_student, null: false, foreign_key: true
+      t.string :point_type, null: false
+      t.integer :points, null: false, default: 0
+      t.string :description, limit: 100
+      t.date :earned_on, null: false
+      t.timestamps
+    end
+
+    add_index :learning_effort_points, [:learning_student_id, :earned_on],
+              name: "index_learning_effort_points_on_student_and_date"
+    add_index :learning_effort_points, [:learning_student_id, :point_type, :earned_on],
+              name: "index_learning_effort_points_on_student_type_date"
+  end
+end

--- a/db/migrate/20260508000004_create_learning_monthly_reports.rb
+++ b/db/migrate/20260508000004_create_learning_monthly_reports.rb
@@ -1,0 +1,17 @@
+class CreateLearningMonthlyReports < ActiveRecord::Migration[6.1]
+  def change
+    create_table :learning_monthly_reports do |t|
+      t.references :customer, null: false, foreign_key: true
+      t.date :report_month, null: false
+      t.integer :total_students, default: 0, null: false
+      t.integer :total_progress_logs, default: 0, null: false
+      t.integer :total_achieved_trainings, default: 0, null: false
+      t.decimal :avg_achievement_rate, precision: 5, scale: 2, default: 0
+      t.string :status, default: "generated", null: false
+      t.timestamps
+    end
+
+    add_index :learning_monthly_reports, [:customer_id, :report_month],
+              unique: true, name: "index_learning_monthly_reports_on_customer_and_month"
+  end
+end

--- a/db/migrate/20260508000005_create_learning_portal_accesses.rb
+++ b/db/migrate/20260508000005_create_learning_portal_accesses.rb
@@ -1,0 +1,13 @@
+class CreateLearningPortalAccesses < ActiveRecord::Migration[6.1]
+  def change
+    create_table :learning_portal_accesses do |t|
+      t.references :learning_student, null: false, foreign_key: true
+      t.date :accessed_on, null: false
+      t.integer :streak_count, default: 1, null: false
+      t.timestamps
+    end
+
+    add_index :learning_portal_accesses, [:learning_student_id, :accessed_on],
+              unique: true, name: "index_learning_portal_accesses_unique_daily"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2026_05_07_130000) do
+ActiveRecord::Schema.define(version: 2026_05_08_000005) do
 
   create_table "active_admin_comments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "namespace"
@@ -404,6 +404,45 @@ ActiveRecord::Schema.define(version: 2026_05_07_130000) do
     t.index ["customer_id"], name: "index_learning_bands_on_customer_id"
   end
 
+  create_table "learning_effort_points", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "customer_id", null: false
+    t.bigint "learning_student_id", null: false
+    t.string "point_type", null: false
+    t.integer "points", default: 0, null: false
+    t.string "description", limit: 100
+    t.date "earned_on", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["customer_id"], name: "index_learning_effort_points_on_customer_id"
+    t.index ["learning_student_id", "earned_on"], name: "index_learning_effort_points_on_student_and_date"
+    t.index ["learning_student_id", "point_type", "earned_on"], name: "index_learning_effort_points_on_student_type_date"
+    t.index ["learning_student_id"], name: "index_learning_effort_points_on_learning_student_id"
+  end
+
+  create_table "learning_monthly_reports", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "customer_id", null: false
+    t.date "report_month", null: false
+    t.integer "total_students", default: 0, null: false
+    t.integer "total_progress_logs", default: 0, null: false
+    t.integer "total_achieved_trainings", default: 0, null: false
+    t.decimal "avg_achievement_rate", precision: 5, scale: 2, default: "0.0"
+    t.string "status", default: "generated", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["customer_id", "report_month"], name: "index_learning_monthly_reports_on_customer_and_month", unique: true
+    t.index ["customer_id"], name: "index_learning_monthly_reports_on_customer_id"
+  end
+
+  create_table "learning_portal_accesses", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "learning_student_id", null: false
+    t.date "accessed_on", null: false
+    t.integer "streak_count", default: 1, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["learning_student_id", "accessed_on"], name: "index_learning_portal_accesses_unique_daily", unique: true
+    t.index ["learning_student_id"], name: "index_learning_portal_accesses_on_learning_student_id"
+  end
+
   create_table "learning_progress_logs", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "customer_id", null: false
     t.bigint "learning_student_id", null: false
@@ -428,7 +467,10 @@ ActiveRecord::Schema.define(version: 2026_05_07_130000) do
     t.text "memo"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "school_code", limit: 20
+    t.string "advisor_name", limit: 100
     t.index ["customer_id", "name"], name: "index_learning_school_groups_on_customer_id_and_name", unique: true
+    t.index ["customer_id", "school_code"], name: "index_learning_school_groups_on_customer_and_code", unique: true
     t.index ["customer_id"], name: "index_learning_school_groups_on_customer_id"
   end
 
@@ -479,6 +521,9 @@ ActiveRecord::Schema.define(version: 2026_05_07_130000) do
     t.bigint "learning_school_group_id"
     t.string "email"
     t.string "public_access_token"
+    t.string "nickname", limit: 30
+    t.boolean "tutorial_completed", default: false, null: false
+    t.integer "total_effort_points", default: 0, null: false
     t.index ["customer_id", "email"], name: "index_learning_students_on_customer_id_and_email"
     t.index ["customer_id", "learning_school_group_id"], name: "index_learning_students_on_customer_and_school_group"
     t.index ["customer_id", "name"], name: "index_learning_students_on_customer_id_and_name"
@@ -833,6 +878,10 @@ ActiveRecord::Schema.define(version: 2026_05_07_130000) do
   add_foreign_key "learning_band_trainings", "learning_bands"
   add_foreign_key "learning_band_trainings", "learning_training_masters"
   add_foreign_key "learning_bands", "customers"
+  add_foreign_key "learning_effort_points", "customers"
+  add_foreign_key "learning_effort_points", "learning_students"
+  add_foreign_key "learning_monthly_reports", "customers"
+  add_foreign_key "learning_portal_accesses", "learning_students"
   add_foreign_key "learning_progress_logs", "customers"
   add_foreign_key "learning_progress_logs", "learning_student_trainings"
   add_foreign_key "learning_progress_logs", "learning_students"

--- a/spec/factories/learning_students.rb
+++ b/spec/factories/learning_students.rb
@@ -1,0 +1,63 @@
+FactoryBot.define do
+  factory :learning_student do
+    customer
+    sequence(:name) { |n| "生徒#{n}" }
+    main_part { "guitar" }
+    status { "active" }
+    total_effort_points { 0 }
+    tutorial_completed { false }
+
+    trait :with_nickname do
+      nickname { "ギター君" }
+    end
+
+    trait :tutorial_done do
+      tutorial_completed { true }
+    end
+
+    trait :in_group do
+      association :learning_school_group
+    end
+  end
+
+  factory :learning_school_group do
+    customer
+    sequence(:name) { |n| "○○高校#{n}" }
+  end
+
+  factory :learning_effort_point do
+    customer
+    learning_student
+    point_type { "progress_log" }
+    points { 5 }
+    description { "練習記録: コード練習" }
+    earned_on { Date.current }
+  end
+
+  factory :learning_portal_access do
+    learning_student
+    accessed_on { Date.current }
+    streak_count { 1 }
+  end
+
+  factory :learning_progress_log do
+    customer
+    learning_student
+    part { "guitar" }
+    training_title { "コード練習" }
+    practiced_on { Date.current }
+    achievement_mark { "triangle" }
+  end
+
+  factory :learning_student_training do
+    customer
+    learning_student
+    part { "guitar" }
+    period { "1-2ヶ月" }
+    level { "基礎" }
+    title { "コード練習" }
+    description { "Cコードを正確に押さえる" }
+    status { "not_started" }
+    achievement_mark { "cross" }
+  end
+end

--- a/spec/models/learning_effort_point_spec.rb
+++ b/spec/models/learning_effort_point_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+RSpec.describe LearningEffortPoint, type: :model do
+  describe "validations" do
+    it "有効なレコードが作成できること" do
+      record = build(:learning_effort_point)
+      expect(record).to be_valid
+    end
+
+    it "point_typeが不正な場合は無効であること" do
+      record = build(:learning_effort_point, point_type: "invalid_type")
+      expect(record).not_to be_valid
+    end
+
+    it "earned_onがない場合は無効であること" do
+      record = build(:learning_effort_point, earned_on: nil)
+      expect(record).not_to be_valid
+    end
+  end
+
+  describe "scopes" do
+    let!(:today_point) { create(:learning_effort_point, earned_on: Date.current) }
+    let!(:old_point)   { create(:learning_effort_point, earned_on: 2.months.ago) }
+
+    it "this_month returns only current month records" do
+      expect(described_class.this_month).to include(today_point)
+      expect(described_class.this_month).not_to include(old_point)
+    end
+
+    it "this_week returns only current week records" do
+      expect(described_class.this_week).to include(today_point)
+    end
+  end
+end

--- a/spec/models/learning_portal_access_spec.rb
+++ b/spec/models/learning_portal_access_spec.rb
@@ -1,0 +1,74 @@
+require "rails_helper"
+
+RSpec.describe LearningPortalAccess, type: :model do
+  describe ".record_access!" do
+    let(:student) { create(:learning_student) }
+
+    context "初回アクセス時" do
+      it "アクセス記録が作成されること" do
+        expect { described_class.record_access!(student) }
+          .to change { described_class.count }.by(1)
+      end
+
+      it "streak_countが1になること" do
+        described_class.record_access!(student)
+        expect(described_class.last.streak_count).to eq(1)
+      end
+    end
+
+    context "同日に2回アクセスした場合" do
+      before { described_class.record_access!(student) }
+
+      it "重複レコードが作成されないこと" do
+        expect { described_class.record_access!(student) }
+          .not_to change { described_class.count }
+      end
+    end
+
+    context "前日にアクセス済みの場合" do
+      before do
+        create(:learning_portal_access,
+               learning_student: student,
+               accessed_on: Date.current - 1,
+               streak_count: 3)
+      end
+
+      it "streak_countが前日+1になること" do
+        described_class.record_access!(student)
+        expect(described_class.find_by(accessed_on: Date.current).streak_count).to eq(4)
+      end
+    end
+
+    context "7日連続アクセス時" do
+      before do
+        create(:learning_portal_access,
+               learning_student: student,
+               accessed_on: Date.current - 1,
+               streak_count: 6)
+      end
+
+      it "streak_bonusポイントが付与されること" do
+        expect { described_class.record_access!(student) }
+          .to change { LearningEffortPoint.where(point_type: "streak_bonus").count }.by(1)
+      end
+
+      it "total_effort_pointsが加算されること" do
+        described_class.record_access!(student)
+        expect(student.reload.total_effort_points).to eq(10)
+      end
+    end
+  end
+
+  describe ".current_streak" do
+    let(:student) { create(:learning_student) }
+
+    it "今日アクセス済みの場合、streak_countを返すこと" do
+      create(:learning_portal_access, learning_student: student, accessed_on: Date.current, streak_count: 5)
+      expect(described_class.current_streak(student)).to eq(5)
+    end
+
+    it "今日未アクセスの場合、0を返すこと" do
+      expect(described_class.current_streak(student)).to eq(0)
+    end
+  end
+end

--- a/spec/services/learning/csv_exporter_spec.rb
+++ b/spec/services/learning/csv_exporter_spec.rb
@@ -1,0 +1,54 @@
+require "rails_helper"
+
+RSpec.describe Learning::CsvExporter do
+  describe ".students_progress" do
+    let(:customer) { create(:customer) }
+    let!(:student) do
+      create(:learning_student, customer: customer, name: "田中太郎",
+             nickname: "たろう", total_effort_points: 30)
+    end
+    let!(:training_achieved) do
+      create(:learning_student_training, customer: customer,
+             learning_student: student, status: "achieved")
+    end
+    let!(:training_in_progress) do
+      create(:learning_student_training, customer: customer,
+             learning_student: student, status: "in_progress")
+    end
+
+    subject(:csv_string) { described_class.students_progress(customer) }
+
+    it "CSVが生成されること" do
+      expect(csv_string).to be_a(String)
+    end
+
+    it "ヘッダー行が含まれること" do
+      expect(csv_string).to include("名前")
+      expect(csv_string).to include("努力ポイント")
+    end
+
+    it "生徒のデータが含まれること" do
+      expect(csv_string).to include("田中太郎")
+      expect(csv_string).to include("たろう")
+    end
+
+    it "達成率が正しく計算されること" do
+      # 2課題中1達成 = 50%
+      expect(csv_string).to include("50.0")
+    end
+
+    it "努力ポイントが含まれること" do
+      expect(csv_string).to include("30")
+    end
+
+    context "非アクティブな生徒がいる場合" do
+      let!(:graduated_student) do
+        create(:learning_student, customer: customer, name: "卒業生", status: "graduated")
+      end
+
+      it "非アクティブな生徒は含まれないこと" do
+        expect(csv_string).not_to include("卒業生")
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Phase1: LearningStudentにnickname/tutorial_completed/total_effort_pointsを追加
  - display_name, achievement_rate, rank_within_group メソッドを追加
  - active scopeを追加
- Phase1: LearningSchoolGroupにschool_code/advisor_nameを追加
- Phase2: LearningEffortPointモデル追加（練習記録+5pt/課題達成+20pt）
  - ProgressLog作成・Training達成時にコールバックで自動付与
  - 同日/同課題の二重付与防止ロジック実装
- Phase3: LearningMonthlyReportモデル追加
  - Learning::MonthlyReportGenerator Serviceを実装
  - Learning::CsvExporter Serviceを実装
  - 顧問ダッシュボード（teacher_dashboards）Controller/View追加
  - CSVエクスポート機能追加（UTF-8 BOM付き）
- Phase4: LearningPortalAccessモデル追加（連続アクセス記録）
  - 7日連続でstreak_bonusポイント付与
  - StudentPortalControllerに連続記録・ポイント・ランキング表示を追加
  - 生徒ポータルViewに努力ポイント・連続日数・チュートリアルオーバーレイを追加
- Phase5: Learning::WeeklyReminderJob追加（週1メール通知）
  - Learning::MonthlyReportJob追加（月次レポート自動生成）
- ルーティングにteacher_dashboard・complete_tutorialを追加
- RSpec追加（19件全通過）