### PR TITLE
feat: 学校導入率向上のためLearning導線ページ4本を追加する

### DIFF
--- a/app/assets/stylesheets/learning_school_pages.scss
+++ b/app/assets/stylesheets/learning_school_pages.scss
@@ -1,0 +1,866 @@
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// BeMyStyle Learning — 学校導入ページ共通スタイル
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+// ── Design Tokens ──────────────────────────
+$lp-primary:    #4f7ef8;
+$lp-primary-dk: #3462d6;
+$lp-accent:     #ff8f70;
+$lp-dark:       #1a1f36;
+$lp-text:       #3d4358;
+$lp-muted:      #8891a8;
+$lp-light-bg:   #f6f8ff;
+$lp-white:      #ffffff;
+$lp-border:     #e4e8f0;
+$lp-radius:     14px;
+$lp-shadow:     0 4px 24px rgba(79, 126, 248, 0.10);
+$lp-shadow-lg:  0 8px 40px rgba(79, 126, 248, 0.16);
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// GLOBAL
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+.lp-body {
+  font-family: "Hiragino Kaku Gothic ProN", "Hiragino Sans", Meiryo, sans-serif;
+  color: $lp-text;
+  background: $lp-white;
+  -webkit-font-smoothing: antialiased;
+}
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// HEADER
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+.lp-header {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  background: rgba(255, 255, 255, 0.96);
+  backdrop-filter: blur(8px);
+  border-bottom: 1px solid $lp-border;
+  padding: 0 24px;
+}
+
+.lp-header__inner {
+  max-width: 1100px;
+  margin: 0 auto;
+  height: 64px;
+  display: flex;
+  align-items: center;
+  gap: 32px;
+}
+
+.lp-header__brand {
+  text-decoration: none;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 700;
+  color: $lp-dark;
+  font-size: 18px;
+  flex-shrink: 0;
+  small { font-size: 12px; color: $lp-primary; font-weight: 600; display: block; line-height: 1; }
+}
+
+.lp-header__brand-icon { font-size: 22px; }
+
+.lp-header__nav {
+  display: flex;
+  gap: 4px;
+  flex: 1;
+  @media (max-width: 640px) { display: none; }
+}
+
+.lp-header__nav-link {
+  padding: 8px 14px;
+  border-radius: 8px;
+  text-decoration: none;
+  color: $lp-muted;
+  font-size: 14px;
+  font-weight: 500;
+  transition: 0.15s;
+  &:hover { color: $lp-primary; background: rgba($lp-primary, 0.06); }
+}
+
+.lp-header__cta {
+  margin-left: auto;
+  background: $lp-primary;
+  color: $lp-white;
+  border-radius: 10px;
+  padding: 10px 20px;
+  font-size: 14px;
+  font-weight: 700;
+  text-decoration: none;
+  white-space: nowrap;
+  transition: 0.15s;
+  &:hover { background: $lp-primary-dk; color: $lp-white; }
+}
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// BUTTONS
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+.lp-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  border-radius: $lp-radius;
+  font-weight: 700;
+  text-decoration: none;
+  padding: 12px 24px;
+  font-size: 15px;
+  border: none;
+  cursor: pointer;
+  transition: 0.15s;
+
+  &--primary {
+    background: $lp-primary;
+    color: $lp-white;
+    box-shadow: 0 4px 16px rgba($lp-primary, 0.35);
+    &:hover { background: $lp-primary-dk; color: $lp-white; transform: translateY(-1px); box-shadow: 0 6px 20px rgba($lp-primary, 0.4); }
+  }
+
+  &--ghost {
+    background: transparent;
+    color: $lp-primary;
+    border: 2px solid $lp-primary;
+    &:hover { background: rgba($lp-primary, 0.06); color: $lp-primary; }
+  }
+
+  &--lg { padding: 14px 32px; font-size: 16px; }
+  &--xl { padding: 18px 48px; font-size: 18px; border-radius: 18px; }
+  &--block { width: 100%; justify-content: center; }
+}
+
+.lp-btn__arrow { font-size: 18px; }
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// SECTIONS
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+.lp-section {
+  padding: 72px 24px;
+  &--light { background: $lp-light-bg; }
+  &--accent {
+    background: linear-gradient(135deg, $lp-dark 0%, #2d3561 100%);
+    color: $lp-white;
+  }
+}
+
+.lp-section__title {
+  font-size: 28px;
+  font-weight: 800;
+  color: $lp-dark;
+  text-align: center;
+  margin-bottom: 40px;
+  &--white { color: $lp-white; }
+
+  @media (max-width: 640px) { font-size: 22px; }
+}
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// HERO
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+.lp-hero {
+  background: linear-gradient(160deg, #eef3ff 0%, #f8f0ff 100%);
+  padding: 80px 24px 64px;
+}
+
+.lp-hero__inner {
+  max-width: 1100px;
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: 1fr 400px;
+  gap: 48px;
+  align-items: center;
+
+  @media (max-width: 900px) {
+    grid-template-columns: 1fr;
+    .lp-hero__visual { order: -1; }
+  }
+}
+
+.lp-hero__eyebrow {
+  font-size: 14px;
+  font-weight: 700;
+  color: $lp-primary;
+  background: rgba($lp-primary, 0.1);
+  display: inline-block;
+  padding: 4px 12px;
+  border-radius: 20px;
+  margin-bottom: 16px;
+}
+
+.lp-hero__title {
+  font-size: 44px;
+  font-weight: 900;
+  line-height: 1.2;
+  color: $lp-dark;
+  margin-bottom: 20px;
+
+  @media (max-width: 640px) { font-size: 30px; }
+}
+
+.lp-hero__accent {
+  color: $lp-primary;
+  background: linear-gradient(135deg, $lp-primary, $lp-accent);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.lp-hero__lead {
+  font-size: 17px;
+  line-height: 1.75;
+  color: $lp-muted;
+  margin-bottom: 32px;
+}
+
+.lp-hero__actions {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+  margin-bottom: 16px;
+}
+
+.lp-hero__note {
+  font-size: 13px;
+  color: $lp-muted;
+}
+
+// ── Mock UI ──────────────────────────
+.lp-mock {
+  background: $lp-white;
+  border-radius: 20px;
+  box-shadow: $lp-shadow-lg;
+  overflow: hidden;
+}
+
+.lp-mock__header {
+  background: #f0f2f5;
+  padding: 12px 16px;
+  display: flex;
+  gap: 6px;
+}
+
+.lp-mock__dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: #d0d3db;
+}
+
+.lp-mock__body {
+  padding: 20px;
+  display: grid;
+  gap: 12px;
+}
+
+.lp-mock__stat {
+  background: $lp-light-bg;
+  border-radius: 10px;
+  padding: 12px 16px;
+}
+
+.lp-mock__label { font-size: 12px; color: $lp-muted; display: block; }
+.lp-mock__value { font-size: 20px; font-weight: 800; color: $lp-dark; }
+
+.lp-mock__bar {
+  height: 6px;
+  background: #e4e8f0;
+  border-radius: 3px;
+  margin-top: 8px;
+  overflow: hidden;
+}
+
+.lp-mock__bar-fill {
+  height: 100%;
+  background: linear-gradient(90deg, $lp-primary, $lp-accent);
+  border-radius: 3px;
+}
+
+.lp-mock__card {
+  background: $lp-white;
+  border: 1px solid $lp-border;
+  border-radius: 10px;
+  padding: 12px 16px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.lp-mock__badge {
+  font-size: 12px;
+  font-weight: 700;
+  background: #fff7e0;
+  color: #c07800;
+  border-radius: 20px;
+  padding: 2px 10px;
+
+  &--wip {
+    background: rgba($lp-primary, 0.1);
+    color: $lp-primary;
+  }
+}
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// PAIN GRID
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+.lp-pain-grid {
+  max-width: 900px;
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 20px;
+
+  @media (max-width: 640px) { grid-template-columns: 1fr; }
+}
+
+.lp-pain-card {
+  background: $lp-white;
+  border: 1px solid $lp-border;
+  border-radius: $lp-radius;
+  padding: 24px;
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  box-shadow: $lp-shadow;
+}
+
+.lp-pain-card__icon { font-size: 28px; flex-shrink: 0; }
+.lp-pain-card__text { font-size: 15px; font-weight: 600; color: $lp-dark; margin: 0; }
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// SOLUTION GRID
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+.lp-solution-grid {
+  max-width: 960px;
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 24px;
+
+  @media (max-width: 640px) { grid-template-columns: 1fr; }
+}
+
+.lp-solution-card {
+  background: $lp-white;
+  border: 1px solid $lp-border;
+  border-radius: $lp-radius;
+  padding: 28px;
+  box-shadow: $lp-shadow;
+  transition: 0.2s;
+  &:hover { transform: translateY(-2px); box-shadow: $lp-shadow-lg; }
+}
+
+.lp-solution-card__icon { font-size: 32px; margin-bottom: 12px; }
+.lp-solution-card__title { font-size: 18px; font-weight: 800; color: $lp-dark; margin-bottom: 8px; }
+.lp-solution-card__body { font-size: 14px; color: $lp-muted; line-height: 1.75; margin: 0; }
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// NUMBERS
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+.lp-number-grid {
+  max-width: 720px;
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 24px;
+  text-align: center;
+
+  @media (max-width: 640px) { grid-template-columns: 1fr; }
+}
+
+.lp-number-card__value {
+  display: block;
+  font-size: 48px;
+  font-weight: 900;
+  color: $lp-white;
+  line-height: 1;
+  margin-bottom: 8px;
+}
+
+.lp-number-card__label {
+  font-size: 14px;
+  color: rgba(255, 255, 255, 0.75);
+  margin: 0;
+}
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// FEATURE TABLE
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+.lp-feature-table {
+  max-width: 760px;
+  margin: 0 auto;
+  display: grid;
+  gap: 12px;
+}
+
+.lp-feature-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 16px;
+  padding: 16px 20px;
+  background: $lp-white;
+  border: 1px solid $lp-border;
+  border-radius: $lp-radius;
+}
+
+.lp-feature-row__icon { font-size: 20px; flex-shrink: 0; margin-top: 2px; }
+.lp-feature-row__body {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  strong { font-size: 15px; font-weight: 700; color: $lp-dark; }
+  span { font-size: 14px; color: $lp-muted; }
+}
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// MONITOR BOX
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+.lp-monitor-box {
+  max-width: 680px;
+  margin: 0 auto;
+  background: linear-gradient(135deg, #f0f4ff, #fff0eb);
+  border: 2px solid rgba($lp-primary, 0.2);
+  border-radius: 24px;
+  padding: 48px;
+  text-align: center;
+
+  @media (max-width: 640px) { padding: 32px 20px; }
+}
+
+.lp-monitor-box__badge {
+  display: inline-block;
+  background: $lp-accent;
+  color: $lp-white;
+  font-size: 13px;
+  font-weight: 700;
+  border-radius: 20px;
+  padding: 4px 16px;
+  margin-bottom: 20px;
+}
+
+.lp-monitor-box__title {
+  font-size: 24px;
+  font-weight: 800;
+  color: $lp-dark;
+  margin-bottom: 12px;
+
+  @media (max-width: 640px) { font-size: 20px; }
+}
+
+.lp-monitor-box__body {
+  font-size: 15px;
+  color: $lp-muted;
+  line-height: 1.75;
+  margin-bottom: 24px;
+}
+
+.lp-monitor-box__list {
+  list-style: none;
+  padding: 0;
+  margin: 0 auto 32px;
+  display: inline-flex;
+  flex-direction: column;
+  gap: 8px;
+  text-align: left;
+
+  li { font-size: 15px; color: $lp-dark; font-weight: 500; }
+}
+
+.lp-monitor-box__note {
+  margin-top: 16px;
+  font-size: 13px;
+  color: $lp-muted;
+}
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// FAQ
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+.lp-faq {
+  max-width: 760px;
+  margin: 0 auto;
+  display: grid;
+  gap: 16px;
+}
+
+.lp-faq__item {
+  border: 1px solid $lp-border;
+  border-radius: $lp-radius;
+  overflow: hidden;
+}
+
+.lp-faq__q {
+  background: $lp-white;
+  padding: 16px 20px;
+  font-weight: 700;
+  color: $lp-dark;
+  margin: 0;
+  &::before { content: "Q. "; color: $lp-primary; }
+}
+
+.lp-faq__a {
+  background: $lp-light-bg;
+  padding: 16px 20px;
+  font-size: 14px;
+  color: $lp-muted;
+  margin: 0;
+  line-height: 1.75;
+  &::before { content: "A. "; color: $lp-muted; font-weight: 700; }
+}
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// FINAL CTA
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+.lp-cta-final {
+  background: $lp-dark;
+  text-align: center;
+  padding: 80px 24px;
+}
+
+.lp-cta-final__title {
+  font-size: 32px;
+  font-weight: 900;
+  color: $lp-white;
+  margin-bottom: 12px;
+
+  @media (max-width: 640px) { font-size: 24px; }
+}
+
+.lp-cta-final__body {
+  font-size: 16px;
+  color: rgba(255, 255, 255, 0.7);
+  margin-bottom: 32px;
+}
+
+.lp-cta-final__sub {
+  margin-top: 20px;
+  a { color: rgba(255, 255, 255, 0.6); font-size: 14px; text-decoration: underline; }
+  span { color: rgba(255, 255, 255, 0.3); margin: 0 8px; }
+}
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// PAGE HERO (guide/apply/student_start)
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+.lp-page-hero {
+  padding: 64px 24px 48px;
+  text-align: center;
+
+  &--guide   { background: linear-gradient(135deg, #e8f4ff, #f0f8ff); }
+  &--apply   { background: linear-gradient(135deg, #fff3e8, #fff8f0); }
+  &--student { background: linear-gradient(135deg, #e8fff0, #f0fff5); }
+}
+
+.lp-page-hero__eyebrow {
+  font-size: 13px;
+  font-weight: 700;
+  color: $lp-primary;
+  background: rgba($lp-primary, 0.1);
+  display: inline-block;
+  padding: 4px 14px;
+  border-radius: 20px;
+  margin-bottom: 16px;
+}
+
+.lp-page-hero__title {
+  font-size: 36px;
+  font-weight: 900;
+  color: $lp-dark;
+  margin-bottom: 12px;
+
+  @media (max-width: 640px) { font-size: 26px; }
+}
+
+.lp-page-hero__sub {
+  font-size: 16px;
+  color: $lp-muted;
+  max-width: 560px;
+  margin: 0 auto;
+  line-height: 1.75;
+}
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// STEPS
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+.lp-steps {
+  max-width: 720px;
+  margin: 0 auto;
+  display: grid;
+  gap: 24px;
+  counter-reset: lp-step;
+}
+
+.lp-step {
+  display: grid;
+  grid-template-columns: 64px 1fr;
+  gap: 20px;
+  background: $lp-white;
+  border: 1px solid $lp-border;
+  border-radius: $lp-radius;
+  padding: 28px;
+  box-shadow: $lp-shadow;
+
+  @media (max-width: 640px) { grid-template-columns: 1fr; }
+}
+
+.lp-step__number {
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, $lp-primary, $lp-accent);
+  color: $lp-white;
+  font-size: 24px;
+  font-weight: 900;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.lp-step__title { font-size: 18px; font-weight: 800; color: $lp-dark; margin-bottom: 8px; }
+.lp-step__desc  { font-size: 15px; color: $lp-muted; line-height: 1.75; margin-bottom: 12px; }
+.lp-step__note  {
+  font-size: 13px;
+  color: $lp-primary;
+  background: rgba($lp-primary, 0.08);
+  border-radius: 8px;
+  padding: 6px 14px;
+  display: inline-block;
+}
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// GUIDE CARDS
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+.lp-guide-cards {
+  max-width: 960px;
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 24px;
+
+  @media (max-width: 768px) { grid-template-columns: 1fr; }
+}
+
+.lp-guide-card {
+  background: $lp-white;
+  border: 1px solid $lp-border;
+  border-radius: $lp-radius;
+  padding: 28px;
+  box-shadow: $lp-shadow;
+  text-align: center;
+}
+
+.lp-guide-card__icon { font-size: 36px; margin-bottom: 12px; }
+.lp-guide-card__title { font-size: 17px; font-weight: 800; color: $lp-dark; margin-bottom: 8px; }
+.lp-guide-card__body  { font-size: 14px; color: $lp-muted; line-height: 1.75; margin: 0; }
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// APPLY FORM
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+.lp-apply-wrap {
+  max-width: 960px;
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: 300px 1fr;
+  gap: 48px;
+  align-items: start;
+
+  @media (max-width: 768px) { grid-template-columns: 1fr; }
+}
+
+.lp-apply-info { padding: 32px; background: $lp-light-bg; border-radius: $lp-radius; }
+.lp-apply-info__title { font-size: 18px; font-weight: 800; color: $lp-dark; margin-bottom: 20px; }
+.lp-apply-info__list {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 20px;
+  display: grid;
+  gap: 10px;
+
+  li { display: flex; align-items: flex-start; gap: 10px; font-size: 14px; color: $lp-dark; font-weight: 500; }
+}
+
+.lp-apply-info__check { font-size: 16px; }
+.lp-apply-info__note { font-size: 13px; color: $lp-muted; line-height: 1.75; p { margin: 0; } }
+
+.lp-apply-form {
+  background: $lp-white;
+  border: 1px solid $lp-border;
+  border-radius: 20px;
+  padding: 40px;
+  box-shadow: $lp-shadow;
+
+  @media (max-width: 640px) { padding: 24px 16px; }
+}
+
+.lp-apply-form-wrap { flex: 1; }
+
+.lp-form-label {
+  display: block;
+  font-size: 14px;
+  font-weight: 700;
+  color: $lp-dark;
+  margin-bottom: 6px;
+}
+
+.lp-form-label__required {
+  font-size: 11px;
+  font-weight: 700;
+  background: $lp-accent;
+  color: $lp-white;
+  border-radius: 4px;
+  padding: 1px 6px;
+  margin-left: 8px;
+}
+
+.lp-form-label__optional {
+  font-size: 11px;
+  color: $lp-muted;
+  margin-left: 8px;
+}
+
+.lp-form-input {
+  width: 100%;
+  border: 1.5px solid $lp-border;
+  border-radius: 10px;
+  padding: 12px 16px;
+  font-size: 15px;
+  color: $lp-dark;
+  transition: 0.15s;
+  appearance: none;
+
+  &:focus {
+    outline: none;
+    border-color: $lp-primary;
+    box-shadow: 0 0 0 3px rgba($lp-primary, 0.12);
+  }
+
+  &.is-invalid { border-color: #dc3545; }
+  &--short { width: 120px; }
+}
+
+.lp-form-note { font-size: 12px; color: $lp-muted; margin-top: 4px; }
+
+.lp-form-submit { margin-top: 32px; }
+
+.lp-form-privacy {
+  margin-top: 12px;
+  font-size: 12px;
+  color: $lp-muted;
+  text-align: center;
+  a { color: $lp-primary; }
+}
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// POINT GRID (student_start)
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+.lp-point-grid {
+  max-width: 800px;
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 24px;
+
+  @media (max-width: 640px) { grid-template-columns: 1fr; }
+}
+
+.lp-point-card {
+  background: $lp-white;
+  border: 1px solid $lp-border;
+  border-radius: $lp-radius;
+  padding: 28px 20px;
+  text-align: center;
+  box-shadow: $lp-shadow;
+}
+
+.lp-point-card__icon   { font-size: 36px; margin-bottom: 12px; }
+.lp-point-card__title  { font-size: 15px; font-weight: 700; color: $lp-dark; margin-bottom: 8px; }
+.lp-point-card__value  {
+  font-size: 28px;
+  font-weight: 900;
+  color: $lp-primary;
+  margin-bottom: 8px;
+  display: block;
+}
+.lp-point-card__desc   { font-size: 13px; color: $lp-muted; margin: 0; line-height: 1.7; }
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// FLOW
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+.lp-flow {
+  max-width: 900px;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.lp-flow__item {
+  background: $lp-white;
+  border: 1px solid $lp-border;
+  border-radius: $lp-radius;
+  padding: 20px;
+  text-align: center;
+  min-width: 140px;
+  box-shadow: $lp-shadow;
+
+  strong { display: block; font-size: 14px; font-weight: 700; color: $lp-dark; margin-bottom: 4px; }
+  p { font-size: 12px; color: $lp-muted; margin: 0; }
+}
+
+.lp-flow__icon { font-size: 28px; margin-bottom: 8px; }
+
+.lp-flow__arrow {
+  font-size: 20px;
+  color: $lp-muted;
+  flex-shrink: 0;
+
+  @media (max-width: 640px) { transform: rotate(90deg); }
+}
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// FOOTER
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+.lp-footer {
+  background: $lp-dark;
+  padding: 48px 24px 0;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.lp-footer__inner {
+  max-width: 1100px;
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 40px;
+  padding-bottom: 40px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+
+  @media (max-width: 640px) { grid-template-columns: 1fr; }
+}
+
+.lp-footer__brand {
+  strong { color: $lp-white; font-size: 16px; display: flex; align-items: center; gap: 8px; }
+  p { font-size: 13px; color: rgba(255, 255, 255, 0.55); margin-top: 8px; }
+}
+
+.lp-footer__icon { font-size: 20px; }
+
+.lp-footer__links {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  a {
+    color: rgba(255, 255, 255, 0.6);
+    text-decoration: none;
+    font-size: 14px;
+    &:hover { color: $lp-white; }
+  }
+}
+
+.lp-footer__copy {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 20px 0;
+  small { font-size: 12px; color: rgba(255, 255, 255, 0.35); }
+}

--- a/app/controllers/learning/pages_controller.rb
+++ b/app/controllers/learning/pages_controller.rb
@@ -1,0 +1,34 @@
+class Learning::PagesController < ApplicationController
+  skip_before_action :authenticate_customer!
+  layout "learning_public"
+
+  def school
+  end
+
+  def guide
+  end
+
+  def apply
+    @application = LearningSchoolApplication.new
+  end
+
+  def create_apply
+    @application = LearningSchoolApplication.new(application_params)
+    if @application.save
+      redirect_to learning_apply_path, notice: "申し込みを受け付けました。担当者より2営業日以内にご連絡いたします。"
+    else
+      render :apply, status: :unprocessable_entity
+    end
+  end
+
+  def student_start
+  end
+
+  private
+
+  def application_params
+    params.require(:learning_school_application).permit(
+      :school_name, :advisor_name, :email, :student_count, :message
+    )
+  end
+end

--- a/app/models/learning_school_application.rb
+++ b/app/models/learning_school_application.rb
@@ -1,0 +1,14 @@
+class LearningSchoolApplication < ApplicationRecord
+  STATUSES = %w[pending contacted adopted rejected].freeze
+
+  validates :school_name,  presence: true, length: { maximum: 100 }
+  validates :advisor_name, presence: true, length: { maximum: 50 }
+  validates :email, presence: true, length: { maximum: 255 },
+                    format: { with: URI::MailTo::EMAIL_REGEXP, message: "はメールアドレス形式で入力してください" }
+  validates :student_count, numericality: { only_integer: true, greater_than: 0, allow_nil: true }
+  validates :message, length: { maximum: 1000 }
+  validates :status, inclusion: { in: STATUSES }
+
+  scope :pending,  -> { where(status: "pending") }
+  scope :recent,   -> { order(created_at: :desc) }
+end

--- a/app/views/layouts/learning_public.html.haml
+++ b/app/views/layouts/learning_public.html.haml
@@ -1,0 +1,47 @@
+!!!
+%html{ lang: "ja" }
+  %head
+    %meta{ content: "text/html; charset=UTF-8", "http-equiv": "Content-Type" }/
+    %meta{ content: "width=device-width,initial-scale=1", name: "viewport" }/
+    %meta{ content: yield(:meta_description).presence || "軽音部の自走を支える学習プラットフォーム | BeMyStyle Learning", name: "description" }/
+    %title= content_for?(:title) ? "#{yield(:title)} | BeMyStyle Learning" : "BeMyStyle Learning"
+    = favicon_link_tag "favicon.ico"
+    = csrf_meta_tags
+    = csp_meta_tag
+    = stylesheet_link_tag "application", media: "all", "data-turbolinks-track": "reload"
+    %link{ rel: "stylesheet", href: "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" }
+    = javascript_include_tag "application", "data-turbolinks-track": "reload"
+
+  %body.lp-body
+    %header.lp-header
+      .lp-header__inner
+        %a.lp-header__brand{ href: learning_school_path }
+          %span.lp-header__brand-icon 🎸
+          %span.lp-header__brand-name
+            BeMyStyle
+            %small Learning
+        %nav.lp-header__nav
+          = link_to "特徴", learning_school_path, class: "lp-header__nav-link"
+          = link_to "顧問ガイド", learning_guide_path, class: "lp-header__nav-link"
+          = link_to "生徒向け", learning_student_start_path, class: "lp-header__nav-link"
+        %a.lp-header__cta{ href: learning_apply_path } 無料モニターに申し込む
+
+    - flash.each do |key, value|
+      .container.mt-3
+        .alert{ class: "alert-#{key == 'notice' ? 'success' : 'danger'}" }= value
+
+    = yield
+
+    %footer.lp-footer
+      .lp-footer__inner
+        .lp-footer__brand
+          %span.lp-footer__icon 🎸
+          %strong BeMyStyle Learning
+          %p 高校軽音部の自走を支える、練習管理プラットフォーム
+        .lp-footer__links
+          = link_to "学校向けLP", learning_school_path
+          = link_to "顧問ガイド", learning_guide_path
+          = link_to "モニター申し込み", learning_apply_path
+          = link_to "生徒向けガイド", learning_student_start_path
+      .lp-footer__copy
+        %small © 2025 BeMyStyle Learning. All rights reserved.

--- a/app/views/learning/pages/apply.html.haml
+++ b/app/views/learning/pages/apply.html.haml
@@ -1,0 +1,87 @@
+- content_for :title, "無料モニター申し込み"
+
+.lp-page-hero.lp-page-hero--apply
+  .container
+    %p.lp-page-hero__eyebrow 無料モニター募集中
+    %h1.lp-page-hero__title お申し込みフォーム
+    %p.lp-page-hero__sub 入力は3項目のみ。お申し込み後2営業日以内にご連絡します。
+
+.lp-section
+  .container
+    .lp-apply-wrap
+      .lp-apply-info
+        %h3.lp-apply-info__title モニター特典
+        %ul.lp-apply-info__list
+          %li
+            %span.lp-apply-info__check ✅
+            費用ゼロ（モニター期間中ずっと無料）
+          %li
+            %span.lp-apply-info__check ✅
+            担当者による導入サポート
+          %li
+            %span.lp-apply-info__check ✅
+            フィードバックを反映した機能改善
+          %li
+            %span.lp-apply-info__check ✅
+            いつでも退会・データ削除可能
+        .lp-apply-info__note
+          %p
+            %strong 現在の募集状況:
+            残り3校（2025年5月時点）
+          %p.text-muted お早めにお申し込みください。
+
+      .lp-apply-form-wrap
+        = form_with model: @application, url: learning_create_apply_path, local: true, class: "lp-apply-form" do |f|
+          - if @application.errors.any?
+            .alert.alert-danger
+              %ul.mb-0
+                - @application.errors.full_messages.each do |msg|
+                  %li= msg
+
+          .mb-4
+            = f.label :school_name, "学校名", class: "lp-form-label"
+            %span.lp-form-label__required 必須
+            = f.text_field :school_name,
+                           placeholder: "○○高等学校",
+                           class: "lp-form-input #{'is-invalid' if @application.errors[:school_name].any?}",
+                           maxlength: 100
+
+          .mb-4
+            = f.label :advisor_name, "顧問のお名前", class: "lp-form-label"
+            %span.lp-form-label__required 必須
+            = f.text_field :advisor_name,
+                           placeholder: "山田 太郎",
+                           class: "lp-form-input #{'is-invalid' if @application.errors[:advisor_name].any?}",
+                           maxlength: 50
+
+          .mb-4
+            = f.label :email, "メールアドレス", class: "lp-form-label"
+            %span.lp-form-label__required 必須
+            = f.email_field :email,
+                            placeholder: "example@school.ac.jp",
+                            class: "lp-form-input #{'is-invalid' if @application.errors[:email].any?}"
+            %p.lp-form-note このアドレスに確認メールを送ります
+
+          .mb-4
+            = f.label :student_count, "部員数（おおよそ）", class: "lp-form-label"
+            %span.lp-form-label__optional 任意
+            = f.number_field :student_count,
+                             placeholder: "20",
+                             min: 1, max: 300,
+                             class: "lp-form-input lp-form-input--short"
+
+          .mb-4
+            = f.label :message, "一言メッセージ・気になること", class: "lp-form-label"
+            %span.lp-form-label__optional 任意
+            = f.text_area :message,
+                          placeholder: "例：ドラムとギターで別々に管理したい、など",
+                          rows: 4,
+                          class: "lp-form-input",
+                          maxlength: 1000
+
+          .lp-form-submit
+            = f.submit "申し込む →", class: "lp-btn lp-btn--primary lp-btn--lg lp-btn--block"
+          %p.lp-form-privacy
+            送信することで
+            = link_to "プライバシーポリシー", public_privacy_path
+            に同意したものとみなします。

--- a/app/views/learning/pages/guide.html.haml
+++ b/app/views/learning/pages/guide.html.haml
@@ -1,0 +1,111 @@
+- content_for :title, "顧問向け操作ガイド"
+
+.lp-page-hero.lp-page-hero--guide
+  .container
+    %p.lp-page-hero__eyebrow 顧問の先生へ
+    %h1.lp-page-hero__title 導入から運用まで、3ステップで完結
+    %p.lp-page-hero__sub ほぼすべての操作はスマートフォンからできます。難しい設定は一切ありません。
+
+.lp-section
+  .container
+
+    -# ━━━━━━━━━━━━━━━━━━━━
+    -# 3ステップ
+    -# ━━━━━━━━━━━━━━━━━━━━
+    %h2.lp-section__title 導入手順（最短15分）
+    .lp-steps
+      .lp-step
+        .lp-step__number 1
+        .lp-step__body
+          %h3.lp-step__title アカウントを作成する
+          %p.lp-step__desc
+            メールアドレスとパスワードだけで登録できます。
+            %br
+            学校名・グループ名（「○○高校軽音部」など）を設定してください。
+          .lp-step__note
+            %strong 所要時間: 約3分
+
+      .lp-step
+        .lp-step__number 2
+        .lp-step__body
+          %h3.lp-step__title 生徒と課題を登録する
+          %p.lp-step__desc
+            生徒リストに部員を追加し、各自のパートに合わせた課題を割り当てます。
+            %br
+            課題テンプレートも用意していますので、最初から作る必要はありません。
+          .lp-step__note
+            %strong 所要時間: 1人あたり約2分（10人で20分目安）
+
+      .lp-step
+        .lp-step__number 3
+        .lp-step__body
+          %h3.lp-step__title ポータルURLを生徒に渡す
+          %p.lp-step__desc
+            生徒ごとに専用URLが自動生成されます。
+            %br
+            LINEやクラスルームで送れば、生徒はすぐに自分の課題を確認できます。
+          .lp-step__note
+            %strong メールアドレス登録で週1リマインドも自動送信
+
+    -# ━━━━━━━━━━━━━━━━━━━━
+    -# 運用方法
+    -# ━━━━━━━━━━━━━━━━━━━━
+    %h2.lp-section__title.mt-5 日々の運用方法
+    .lp-guide-cards
+      .lp-guide-card
+        .lp-guide-card__icon 📅
+        %h3.lp-guide-card__title 週1回（5分）
+        %p.lp-guide-card__body
+          ダッシュボードで全生徒の達成率・最終練習日を一覧確認。
+          %br
+          停滞している生徒にコメントを入れる。
+      .lp-guide-card
+        .lp-guide-card__icon 🗓️
+        %h3.lp-guide-card__title 月1回（10分）
+        %p.lp-guide-card__body
+          月次レポートを確認し、達成が多い生徒を表彰。
+          %br
+          CSVエクスポートで部活動記録として保存。
+      .lp-guide-card
+        .lp-guide-card__icon ⭐
+        %h3.lp-guide-card__title 課題達成時
+        %p.lp-guide-card__body
+          生徒が課題を達成したら、コメント欄で一言フィードバック。
+          %br
+          次の課題を追加して成長をつなぎます。
+
+    -# ━━━━━━━━━━━━━━━━━━━━
+    -# FAQ
+    -# ━━━━━━━━━━━━━━━━━━━━
+    %h2.lp-section__title.mt-5 よくある質問
+    .lp-faq
+      .lp-faq__item
+        %p.lp-faq__q 生徒が直接課題を編集することはできますか？
+        %p.lp-faq__a
+          いいえ。課題の追加・変更は顧問のみが行えます。
+          生徒は練習記録の登録と閲覧のみです。
+      .lp-faq__item
+        %p.lp-faq__q 部活を引退した生徒のデータは？
+        %p.lp-faq__a
+          ステータスを「卒業」に変更すると一覧から非表示になります。
+          データは保持されますのでCSVで取り出せます。
+      .lp-faq__item
+        %p.lp-faq__q 複数の顧問で使えますか？
+        %p.lp-faq__a
+          現在は1アカウントでの運用を想定しています。
+          複数顧問対応はロードマップに含まれています。
+      .lp-faq__item
+        %p.lp-faq__q バンド合わせの管理もできますか？
+        %p.lp-faq__a
+          はい。バンドを登録してメンバーを追加すると、バンド単位で課題を設定できます。
+      .lp-faq__item
+        %p.lp-faq__q データのバックアップ方法は？
+        %p.lp-faq__a
+          顧問ダッシュボードからCSVエクスポートができます。
+          月1回ダウンロードすることをおすすめします。
+
+.lp-section.lp-section--light
+  .container.text-center
+    %h2.lp-section__title 導入してみませんか？
+    %p.mb-4 まずは無料モニターで試してください。設定でお困りの際は担当者がサポートします。
+    = link_to "無料モニターに申し込む →", learning_apply_path, class: "lp-btn lp-btn--primary lp-btn--lg"

--- a/app/views/learning/pages/school.html.haml
+++ b/app/views/learning/pages/school.html.haml
@@ -1,0 +1,211 @@
+- content_for :title, "学校向け紹介"
+- content_for :meta_description, "軽音部顧問のための練習管理プラットフォーム。生徒が自走できる仕組みを、無料でお試しいただけます。"
+
+-# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+-# HERO
+-# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+.lp-hero
+  .container
+    .lp-hero__inner
+      .lp-hero__text
+        %p.lp-hero__eyebrow 🏫 高校軽音部向け
+        %h1.lp-hero__title
+          生徒が
+          %span.lp-hero__accent 自分で動ける
+          軽音部をつくろう
+        %p.lp-hero__lead
+          「次に何を練習すればいい？」と聞いてくる生徒を減らし、
+          %br
+          顧問の負担を下げながら部員の成長を可視化します。
+        .lp-hero__actions
+          %a.lp-btn.lp-btn--primary.lp-btn--lg{ href: learning_apply_path }
+            無料モニターに申し込む
+            %span.lp-btn__arrow →
+          %a.lp-btn.lp-btn--ghost{ href: learning_guide_path } 顧問ガイドを見る
+        .lp-hero__note 申し込み5分・費用ゼロ・いつでも退会OK
+      .lp-hero__visual
+        .lp-mock
+          .lp-mock__header
+            .lp-mock__dot
+            .lp-mock__dot
+            .lp-mock__dot
+          .lp-mock__body
+            .lp-mock__stat
+              %span.lp-mock__label 達成率
+              %strong.lp-mock__value 68%
+              .lp-mock__bar
+                .lp-mock__bar-fill{ style: "width:68%" }
+            .lp-mock__stat
+              %span.lp-mock__label 努力ポイント
+              %strong.lp-mock__value 240 PT
+            .lp-mock__card
+              %strong コード進行をマスター
+              %span.lp-mock__badge ⭐ 達成
+            .lp-mock__card
+              %strong リズムキープ練習
+              %span.lp-mock__badge.lp-mock__badge--wip 進行中
+
+-# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+-# 課題提起
+-# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+.lp-section.lp-section--light
+  .container
+    %h2.lp-section__title こんな悩み、ありませんか？
+    .lp-pain-grid
+      .lp-pain-card
+        %span.lp-pain-card__icon 😰
+        %p.lp-pain-card__text 「次何を練習すればいい？」と聞かれ続ける
+      .lp-pain-card
+        %span.lp-pain-card__icon 📋
+        %p.lp-pain-card__text 生徒の進捗をノートや口頭で管理している
+      .lp-pain-card
+        %span.lp-pain-card__icon 😔
+        %p.lp-pain-card__text 頑張っている生徒が報われているか分からない
+      .lp-pain-card
+        %span.lp-pain-card__icon ⏰
+        %p.lp-pain-card__text 部活以外の時間に個別フォローできない
+
+-# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+-# 解決策
+-# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+.lp-section
+  .container
+    %h2.lp-section__title BeMyStyle Learningが解決します
+    .lp-solution-grid
+      .lp-solution-card
+        .lp-solution-card__icon 📱
+        %h3.lp-solution-card__title 生徒専用ポータル
+        %p.lp-solution-card__body
+          URLを渡すだけで、生徒が自分の課題・コメントをいつでも確認できます。
+          登録不要で今日から使えます。
+      .lp-solution-card
+        .lp-solution-card__icon 🏆
+        %h3.lp-solution-card__title 努力ポイント＆ランキング
+        %p.lp-solution-card__body
+          練習記録のたびにポイント付与。グループ内ランキングで、
+          自分の成長が目に見えてわかります。
+      .lp-solution-card
+        .lp-solution-card__icon 📊
+        %h3.lp-solution-card__title 顧問ダッシュボード
+        %p.lp-solution-card__body
+          全生徒の達成率・最終練習日・努力ポイントを一覧表示。
+          CSVエクスポートで記録も残せます。
+      .lp-solution-card
+        .lp-solution-card__icon ✉️
+        %h3.lp-solution-card__title 週1リマインド通知
+        %p.lp-solution-card__body
+          メールアドレスを登録した生徒に、今週の目標と課題を
+          自動で送信します。
+
+-# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+-# 導入メリット（数字）
+-# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+.lp-section.lp-section--accent
+  .container
+    %h2.lp-section__title.lp-section__title--white 導入で期待できる変化
+    .lp-number-grid
+      .lp-number-card
+        %strong.lp-number-card__value 5分
+        %p.lp-number-card__label 毎日の練習確認にかかる時間
+      .lp-number-card
+        %strong.lp-number-card__value 3ステップ
+        %p.lp-number-card__label 導入完了まで（最短15分）
+      .lp-number-card
+        %strong.lp-number-card__value ¥0
+        %p.lp-number-card__label モニター期間中の費用
+
+-# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+-# 機能一覧
+-# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+.lp-section.lp-section--light
+  .container
+    %h2.lp-section__title 主な機能
+    .lp-feature-table
+      .lp-feature-row
+        .lp-feature-row__icon ✅
+        .lp-feature-row__body
+          %strong 個人課題管理
+          %span パート・レベル・期間別に課題を設定。達成マーク（⭐️△×）で進捗管理
+      .lp-feature-row
+        .lp-feature-row__icon ✅
+        .lp-feature-row__body
+          %strong バンド合わせ管理
+          %span バンド単位でも課題設定可能。メンバー全員の進捗を把握
+      .lp-feature-row
+        .lp-feature-row__icon ✅
+        .lp-feature-row__body
+          %strong 練習記録
+          %span 生徒が毎日の練習内容をログに残せる（コメント付き）
+      .lp-feature-row
+        .lp-feature-row__icon ✅
+        .lp-feature-row__body
+          %strong 努力ポイント自動付与
+          %span 記録するたびにポイントが貯まる。継続ボーナスも
+      .lp-feature-row
+        .lp-feature-row__icon ✅
+        .lp-feature-row__body
+          %strong グループ・ランキング
+          %span 高校単位でグルーピング。ポイントランキングで切磋琢磨
+      .lp-feature-row
+        .lp-feature-row__icon ✅
+        .lp-feature-row__body
+          %strong CSVエクスポート
+          %span 全生徒の達成率・ポイントをCSVで出力。記録提出にも活用可能
+
+-# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+-# モニター案内
+-# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+.lp-section
+  .container
+    .lp-monitor-box
+      .lp-monitor-box__badge 無料モニター募集中
+      %h2.lp-monitor-box__title 2025年度、5校限定で無料モニターを募集しています
+      %p.lp-monitor-box__body
+        導入から運用まで開発チームが伴走します。
+        %br
+        フィードバックをいただくことで、よりよいサービスにしていきます。
+      .lp-monitor-box__list
+        %li ✅ 初期費用・月額費用すべて無料
+        %li ✅ データ移行・初期設定サポートあり
+        %li ✅ 担当者が導入をお手伝い
+        %li ✅ いつでも退会・データ削除可能
+      %a.lp-btn.lp-btn--primary.lp-btn--lg{ href: learning_apply_path }
+        無料モニターに申し込む
+        %span.lp-btn__arrow →
+      %p.lp-monitor-box__note
+        お申し込み後、2営業日以内にメールでご連絡します。
+
+-# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+-# FAQ
+-# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+.lp-section.lp-section--light
+  .container
+    %h2.lp-section__title よくある質問
+    .lp-faq
+      .lp-faq__item
+        %p.lp-faq__q 生徒はアカウント登録が必要ですか？
+        %p.lp-faq__a URLを渡すだけで使えます。生徒側のアカウント登録は不要です。
+      .lp-faq__item
+        %p.lp-faq__q 個人情報の管理は安全ですか？
+        %p.lp-faq__a 生徒はニックネームのみで利用でき、実名・メールアドレスの登録は任意です。
+      .lp-faq__item
+        %p.lp-faq__q スマートフォンから使えますか？
+        %p.lp-faq__a はい。生徒ポータルはスマートフォンに最適化されています。
+      .lp-faq__item
+        %p.lp-faq__q 顧問が複数いる場合は？
+        %p.lp-faq__a 現在は1顧問1アカウントで運用いただいています。複数対応はロードマップに含まれています。
+
+-# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+-# 最終CTA
+-# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+.lp-section.lp-cta-final
+  .container
+    %h2.lp-cta-final__title まずは無料でお試しください
+    %p.lp-cta-final__body 申し込みはメールアドレスだけ。5分で完了します。
+    %a.lp-btn.lp-btn--primary.lp-btn--xl{ href: learning_apply_path }
+      無料モニターに申し込む
+      %span.lp-btn__arrow →
+    .lp-cta-final__sub
+      %a{ href: learning_guide_path } 顧問ガイドを先に見る
+      %span ｜
+      %a{ href: learning_student_start_path } 生徒向けガイドを見る

--- a/app/views/learning/pages/student_start.html.haml
+++ b/app/views/learning/pages/student_start.html.haml
@@ -1,0 +1,116 @@
+- content_for :title, "生徒向けスタートガイド"
+
+.lp-page-hero.lp-page-hero--student
+  .container
+    %p.lp-page-hero__eyebrow 部員のみなさんへ
+    %h1.lp-page-hero__title 練習を楽しく続けよう
+    %p.lp-page-hero__sub ポイントを貯めて、自分の成長を目で確認しながら練習できます。
+
+.lp-section
+  .container
+
+    -# ━━━━━━━━━━━━━━━━━━━━
+    -# 使い方
+    -# ━━━━━━━━━━━━━━━━━━━━
+    %h2.lp-section__title 使い方はとても簡単
+    .lp-steps
+      .lp-step
+        .lp-step__number 1
+        .lp-step__body
+          %h3.lp-step__title 顧問の先生からURLをもらう
+          %p.lp-step__desc
+            先生からLINEやメールでポータルURLが届きます。
+            ブックマークしておくと便利です。
+          .lp-step__note アカウント登録は不要です
+
+      .lp-step
+        .lp-step__number 2
+        .lp-step__body
+          %h3.lp-step__title 自分の課題を確認する
+          %p.lp-step__desc
+            ポータルを開くと、先生が設定してくれた課題と
+            達成マーク（⭐️△×）が表示されます。
+          .lp-step__note 「次にやること」が一目でわかります
+
+      .lp-step
+        .lp-step__number 3
+        .lp-step__body
+          %h3.lp-step__title 練習したら記録をつける
+          %p.lp-step__desc
+            練習したら記録ボタンを押してコメントを入れるだけ。
+            記録するたびにポイントがもらえます。
+          .lp-step__note 1回の記録で5ポイント！
+
+    -# ━━━━━━━━━━━━━━━━━━━━
+    -# ポイント説明
+    -# ━━━━━━━━━━━━━━━━━━━━
+    %h2.lp-section__title.mt-5 努力ポイントのルール
+    .lp-point-grid
+      .lp-point-card
+        .lp-point-card__icon 📝
+        %h3.lp-point-card__title 練習記録
+        .lp-point-card__value +5 PT
+        %p.lp-point-card__desc 練習したら記録するだけ。毎日でも貯まります。
+      .lp-point-card
+        .lp-point-card__icon ⭐
+        %h3.lp-point-card__title 課題達成
+        .lp-point-card__value +20 PT
+        %p.lp-point-card__desc 課題が⭐️になったらボーナス。大きく稼げます。
+      .lp-point-card
+        .lp-point-card__icon 🔥
+        %h3.lp-point-card__title 連続アクセス
+        .lp-point-card__value +10 PT
+        %p.lp-point-card__desc 7日連続でポータルを開くとボーナスポイント。
+
+    -# ━━━━━━━━━━━━━━━━━━━━
+    -# 練習の流れ
+    -# ━━━━━━━━━━━━━━━━━━━━
+    %h2.lp-section__title.mt-5 練習の流れ
+    .lp-flow
+      .lp-flow__item
+        .lp-flow__icon 📱
+        .lp-flow__body
+          %strong ポータルを開く
+          %p 今日やる課題を確認する
+      .lp-flow__arrow →
+      .lp-flow__item
+        .lp-flow__icon 🎸
+        .lp-flow__body
+          %strong 課題を練習する
+          %p 目標・達成基準を意識して取り組む
+      .lp-flow__arrow →
+      .lp-flow__item
+        .lp-flow__icon 📝
+        .lp-flow__body
+          %strong 記録する
+          %p コメントを残してポイントゲット
+      .lp-flow__arrow →
+      .lp-flow__item
+        .lp-flow__icon 📈
+        .lp-flow__body
+          %strong 成長を確認
+          %p 達成率・ランキングで自分の成長を実感
+
+    -# ━━━━━━━━━━━━━━━━━━━━
+    -# FAQ（生徒向け）
+    -# ━━━━━━━━━━━━━━━━━━━━
+    %h2.lp-section__title.mt-5 よくある質問
+    .lp-faq
+      .lp-faq__item
+        %p.lp-faq__q ポータルURLはどこでもらえますか？
+        %p.lp-faq__a 顧問の先生からLINEまたはメールで送ってもらえます。
+      .lp-faq__item
+        %p.lp-faq__q 課題の内容を自分で変えられますか？
+        %p.lp-faq__a 課題の追加・変更は先生のみ行えます。希望があれば先生に相談しましょう。
+      .lp-faq__item
+        %p.lp-faq__q ポイントはどこで確認できますか？
+        %p.lp-faq__a ポータルのトップに「努力ポイント」が表示されます。
+      .lp-faq__item
+        %p.lp-faq__q スマホを機種変更したらURLは変わりますか？
+        %p.lp-faq__a URLは変わりません。ブックマークを新しいスマホに移せばそのまま使えます。
+
+.lp-section.lp-section--light
+  .container.text-center
+    %h2.lp-section__title まずは先生にお願いしてみよう
+    %p.mb-4 このページを先生に見せるだけで、導入の第一歩になります。
+    = link_to "学校向け紹介ページを見る →", learning_school_path, class: "lp-btn lp-btn--primary lp-btn--lg"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -214,6 +214,13 @@ Rails.application.routes.draw do
     get  "join", to: "joins#show", as: :join
     post "join", to: "joins#create"
 
+    # 学校導入導線ページ（認証不要）
+    get  "school",        to: "pages#school",        as: :school
+    get  "guide",         to: "pages#guide",          as: :guide
+    get  "apply",         to: "pages#apply",          as: :apply
+    post "apply",         to: "pages#create_apply",   as: :create_apply
+    get  "student-start", to: "pages#student_start",  as: :student_start
+
     resource :dashboard, only: :show, controller: :dashboards
     get "portal/:token", to: "student_portals#show", as: :student_portal
     resources :school_groups

--- a/db/migrate/20260508010001_create_learning_school_applications.rb
+++ b/db/migrate/20260508010001_create_learning_school_applications.rb
@@ -1,0 +1,16 @@
+class CreateLearningSchoolApplications < ActiveRecord::Migration[6.1]
+  def change
+    create_table :learning_school_applications do |t|
+      t.string  :school_name,   null: false, limit: 100
+      t.string  :advisor_name,  null: false, limit: 50
+      t.string  :email,         null: false, limit: 255
+      t.integer :student_count
+      t.text    :message
+      t.string  :status,        null: false, default: "pending"
+      t.timestamps
+    end
+
+    add_index :learning_school_applications, :email
+    add_index :learning_school_applications, :status
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2026_05_07_130000) do
+ActiveRecord::Schema.define(version: 2026_05_08_010001) do
 
   create_table "active_admin_comments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "namespace"
@@ -404,6 +404,45 @@ ActiveRecord::Schema.define(version: 2026_05_07_130000) do
     t.index ["customer_id"], name: "index_learning_bands_on_customer_id"
   end
 
+  create_table "learning_effort_points", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "customer_id", null: false
+    t.bigint "learning_student_id", null: false
+    t.string "point_type", null: false
+    t.integer "points", default: 0, null: false
+    t.string "description", limit: 100
+    t.date "earned_on", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["customer_id"], name: "index_learning_effort_points_on_customer_id"
+    t.index ["learning_student_id", "earned_on"], name: "index_learning_effort_points_on_student_and_date"
+    t.index ["learning_student_id", "point_type", "earned_on"], name: "index_learning_effort_points_on_student_type_date"
+    t.index ["learning_student_id"], name: "index_learning_effort_points_on_learning_student_id"
+  end
+
+  create_table "learning_monthly_reports", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "customer_id", null: false
+    t.date "report_month", null: false
+    t.integer "total_students", default: 0, null: false
+    t.integer "total_progress_logs", default: 0, null: false
+    t.integer "total_achieved_trainings", default: 0, null: false
+    t.decimal "avg_achievement_rate", precision: 5, scale: 2, default: "0.0"
+    t.string "status", default: "generated", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["customer_id", "report_month"], name: "index_learning_monthly_reports_on_customer_and_month", unique: true
+    t.index ["customer_id"], name: "index_learning_monthly_reports_on_customer_id"
+  end
+
+  create_table "learning_portal_accesses", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "learning_student_id", null: false
+    t.date "accessed_on", null: false
+    t.integer "streak_count", default: 1, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["learning_student_id", "accessed_on"], name: "index_learning_portal_accesses_unique_daily", unique: true
+    t.index ["learning_student_id"], name: "index_learning_portal_accesses_on_learning_student_id"
+  end
+
   create_table "learning_progress_logs", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "customer_id", null: false
     t.bigint "learning_student_id", null: false
@@ -422,13 +461,29 @@ ActiveRecord::Schema.define(version: 2026_05_07_130000) do
     t.index ["learning_student_training_id"], name: "index_learning_progress_logs_on_learning_student_training_id"
   end
 
+  create_table "learning_school_applications", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "school_name", limit: 100, null: false
+    t.string "advisor_name", limit: 50, null: false
+    t.string "email", null: false
+    t.integer "student_count"
+    t.text "message"
+    t.string "status", default: "pending", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["email"], name: "index_learning_school_applications_on_email"
+    t.index ["status"], name: "index_learning_school_applications_on_status"
+  end
+
   create_table "learning_school_groups", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "customer_id", null: false
     t.string "name", null: false
     t.text "memo"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "school_code", limit: 20
+    t.string "advisor_name", limit: 100
     t.index ["customer_id", "name"], name: "index_learning_school_groups_on_customer_id_and_name", unique: true
+    t.index ["customer_id", "school_code"], name: "index_learning_school_groups_on_customer_and_code", unique: true
     t.index ["customer_id"], name: "index_learning_school_groups_on_customer_id"
   end
 
@@ -479,6 +534,9 @@ ActiveRecord::Schema.define(version: 2026_05_07_130000) do
     t.bigint "learning_school_group_id"
     t.string "email"
     t.string "public_access_token"
+    t.string "nickname", limit: 30
+    t.boolean "tutorial_completed", default: false, null: false
+    t.integer "total_effort_points", default: 0, null: false
     t.index ["customer_id", "email"], name: "index_learning_students_on_customer_id_and_email"
     t.index ["customer_id", "learning_school_group_id"], name: "index_learning_students_on_customer_and_school_group"
     t.index ["customer_id", "name"], name: "index_learning_students_on_customer_id_and_name"
@@ -833,6 +891,10 @@ ActiveRecord::Schema.define(version: 2026_05_07_130000) do
   add_foreign_key "learning_band_trainings", "learning_bands"
   add_foreign_key "learning_band_trainings", "learning_training_masters"
   add_foreign_key "learning_bands", "customers"
+  add_foreign_key "learning_effort_points", "customers"
+  add_foreign_key "learning_effort_points", "learning_students"
+  add_foreign_key "learning_monthly_reports", "customers"
+  add_foreign_key "learning_portal_accesses", "learning_students"
   add_foreign_key "learning_progress_logs", "customers"
   add_foreign_key "learning_progress_logs", "learning_student_trainings"
   add_foreign_key "learning_progress_logs", "learning_students"


### PR DESCRIPTION
- /learning/school — 学校向けLP（課題提起→解決策→機能紹介→モニター案内→CTA）
- /learning/guide  — 顧問向けガイド（3ステップ導入手順・運用方法・FAQ）
- /learning/apply  — モニター申し込みフォーム（LearningSchoolApplicationモデル）
- /learning/student-start — 生徒向けスタートガイド（使い方・ポイント説明・練習の流れ）
- learning_publicレイアウト追加（認証不要・Bootstrap・スマホ最適化）
- learning_school_pages.scss（LP専用デザイントークン・全コンポーネント）
- LearningSchoolApplicationモデル（バリデーション付き・ステータス管理）
- マイグレーション: learning_school_applications テーブル作成