### PR TITLE
feat: add learning notification delivery logs

### DIFF
--- a/app/controllers/learning/notifications_controller.rb
+++ b/app/controllers/learning/notifications_controller.rb
@@ -1,6 +1,26 @@
 class Learning::NotificationsController < Learning::BaseController
   def index
     @notification_setting = Learning::NotificationSetting.effective_for(current_customer)
-    @notifications = Learning::NotificationDispatcher.new(current_customer).preview
+    @notifications = notification_dispatcher.preview
+    @notification_logs = current_customer.learning_notification_logs
+      .includes(:learning_student)
+      .order(generated_at: :desc, created_at: :desc)
+      .limit(50)
+  end
+
+  def persist_preview
+    saved_logs = notification_dispatcher.persist_preview!
+
+    if saved_logs.any?
+      redirect_to learning_notifications_path, notice: "今日の通知候補を履歴に保存しました。"
+    else
+      redirect_to learning_notifications_path, alert: "保存できる通知候補はありません。通知設定がOFFの場合は保存されません。"
+    end
+  end
+
+  private
+
+  def notification_dispatcher
+    @notification_dispatcher ||= Learning::NotificationDispatcher.new(current_customer)
   end
 end

--- a/app/controllers/learning/teacher_dashboards_controller.rb
+++ b/app/controllers/learning/teacher_dashboards_controller.rb
@@ -12,6 +12,8 @@ class Learning::TeacherDashboardsController < Learning::BaseController
                                 .ordered
     @monthly_report = LearningMonthlyReport.for_month(current_customer)
     @notification_setting = Learning::NotificationSetting.effective_for(current_customer)
+    @notification_candidates_count = Learning::NotificationDispatcher.new(current_customer).preview.count
+    @notification_logs_count = current_customer.learning_notification_logs.count
     @onboarding_status = Learning::OnboardingStatus.new(current_customer, routes: self)
     @teacher_next_action = Learning::FirstDayExperience.teacher_action(current_customer, routes: self)
     @weekly_growth = build_weekly_growth

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -113,6 +113,9 @@ class Customer < ApplicationRecord
   has_one :learning_notification_setting,
           class_name: "Learning::NotificationSetting",
           dependent: :destroy
+  has_many :learning_notification_logs,
+           class_name: "Learning::NotificationLog",
+           dependent: :destroy
   has_many :singing_diagnoses, dependent: :destroy
   has_many :singing_badges, dependent: :destroy
   has_many :singing_profile_reactions, dependent: :destroy

--- a/app/models/learning/notification_log.rb
+++ b/app/models/learning/notification_log.rb
@@ -1,0 +1,26 @@
+module Learning
+  class NotificationLog < ApplicationRecord
+    self.table_name = "learning_notification_logs"
+
+    NOTIFICATION_TYPES = %w[
+      reminder
+      teacher_action
+      weekly_summary
+      student_reactivation
+    ].freeze
+
+    LEVELS = %w[light normal strong info].freeze
+    DELIVERY_CHANNELS = %w[manual email line].freeze
+    STATUSES = %w[previewed queued sent failed skipped].freeze
+
+    belongs_to :customer
+    belongs_to :learning_student, class_name: "LearningStudent", optional: true
+
+    validates :notification_type, presence: true, inclusion: { in: NOTIFICATION_TYPES }
+    validates :level, inclusion: { in: LEVELS }, allow_blank: true
+    validates :delivery_channel, presence: true, inclusion: { in: DELIVERY_CHANNELS }
+    validates :status, presence: true, inclusion: { in: STATUSES }
+    validates :message, presence: true
+    validates :generated_at, presence: true
+  end
+end

--- a/app/models/learning_student.rb
+++ b/app/models/learning_student.rb
@@ -8,6 +8,9 @@ class LearningStudent < ApplicationRecord
   has_many :learning_bands, through: :learning_band_memberships
   has_many :learning_effort_points, dependent: :destroy
   has_many :learning_portal_accesses, dependent: :destroy
+  has_many :learning_notification_logs,
+           class_name: "Learning::NotificationLog",
+           dependent: :nullify
 
   validates :name, presence: true, length: { maximum: 50 }
   validates :nickname, length: { maximum: 30 }, allow_blank: true

--- a/app/services/learning/notification_dispatcher.rb
+++ b/app/services/learning/notification_dispatcher.rb
@@ -1,8 +1,6 @@
 module Learning
   class NotificationDispatcher
-    Delivery = Struct.new(:reminder, :channel, :status, keyword_init: true)
-
-    CHANNELS = %i[line email app].freeze
+    CHANNELS = %i[line email manual].freeze
 
     def initialize(customer, channels: [])
       @customer = customer
@@ -15,16 +13,21 @@ module Learning
       reminders
     end
 
+    def persist_preview!
+      return [] unless notification_setting.reminder_enabled?
+
+      reminders.filter_map { |reminder| find_or_create_log(reminder) }
+    end
+
     def dispatch
       return [] unless notification_setting.reminder_enabled?
 
-      channels = @channels & CHANNELS
-      return [] if channels.empty?
+      channels = (@channels.presence || [notification_setting.delivery_channel]).map(&:to_sym) & CHANNELS
+      selected_channel = (channels.first || notification_setting.delivery_channel).to_s
+      status = %w[email line].include?(selected_channel) ? "queued" : "skipped"
 
-      reminders.flat_map do |reminder|
-        channels.map do |channel|
-          Delivery.new(reminder: reminder, channel: channel, status: :planned)
-        end
+      persist_preview!.each do |log|
+        log.update!(status: status, delivery_channel: selected_channel)
       end
     end
 
@@ -36,6 +39,36 @@ module Learning
 
     def notification_setting
       @notification_setting ||= NotificationSetting.effective_for(@customer)
+    end
+
+    def find_or_create_log(reminder)
+      existing_log = Learning::NotificationLog
+        .where(
+          customer: @customer,
+          learning_student: reminder.student,
+          notification_type: "reminder"
+        )
+        .where(generated_at: Time.zone.today.all_day)
+        .first
+      return existing_log if existing_log
+
+      Learning::NotificationLog.create!(
+        customer: @customer,
+        learning_student: reminder.student,
+        notification_type: "reminder",
+        level: reminder.level,
+        delivery_channel: notification_setting.delivery_channel,
+        status: "previewed",
+        title: "#{reminder.student.display_name}さんへの通知候補",
+        message: reminder.message,
+        recommended_action: reminder.recommended_action,
+        generated_at: reminder.generated_at,
+        metadata: {
+          stage: reminder.stage,
+          days_idle: reminder.days_idle,
+          source: "Learning::ReminderService"
+        }
+      )
     end
   end
 end

--- a/app/views/learning/notifications/index.html.haml
+++ b/app/views/learning/notifications/index.html.haml
@@ -1,11 +1,18 @@
-= render "learning/shared/page", title: "通知ログ", subtitle: "ReminderService が今この瞬間に返す通知候補を確認できます。DB保存はせず、その場で生成しています。" do
+= render "learning/shared/page", title: "通知ログ", subtitle: "LINE/メール実配信前に、通知候補と保存済み履歴を確認できます。実送信はまだ行いません。" do
   .learning-section
     .learning-section__header
-      %h2 通知候補
+      %h2 今日の通知候補
       .learning-section__actions
         %span.learning-notification-current= "現在の通知方式：#{@notification_setting.delivery_channel_label}"
+        = button_to "今日の通知候補を履歴に保存",
+                    persist_preview_learning_notifications_path,
+                    method: :post,
+                    class: "learning-button learning-button--sm"
         = link_to "通知設定を変更", edit_learning_notification_settings_path, class: "learning-button learning-button--ghost learning-button--sm"
         = link_to "顧問ダッシュボードへ", learning_teacher_dashboard_path, class: "learning-button learning-button--ghost learning-button--sm"
+    .learning-empty
+      %strong 実送信はまだ行いません
+      %p LINE/メール送信は準備中です。ここでは通知候補を履歴に保存し、手動コピーで安全に運用できます。
 
     .learning-table-wrap
       %table.learning-table
@@ -38,3 +45,45 @@
                   - else
                     %strong 生徒リマインド通知はOFFです
                     %p 通知設定をONにすると、対象生徒の通知候補がここに表示されます。
+
+  .learning-section
+    .learning-section__header
+      %h2 保存済み通知履歴
+      %small= "最新#{@notification_logs.size}件"
+
+    .learning-table-wrap
+      %table.learning-table
+        %thead
+          %tr
+            %th 対象生徒
+            %th 種別
+            %th レベル
+            %th ステータス
+            %th メッセージ
+            %th 推奨アクション
+            %th 生成日時
+        %tbody
+          - if @notification_logs.any?
+            - @notification_logs.each do |log|
+              %tr
+                %td
+                  - if log.learning_student
+                    = link_to log.learning_student.display_name, learning_student_path(log.learning_student)
+                  - else
+                    = "-"
+                %td= log.notification_type
+                %td
+                  - if log.level.present?
+                    %span.learning-notification-level{ class: "learning-notification-level--#{log.level}" }= log.level
+                  - else
+                    = "-"
+                %td= log.status
+                %td= log.message
+                %td= log.recommended_action.presence || "-"
+                %td= l(log.generated_at, format: :short)
+          - else
+            %tr
+              %td{ colspan: 7 }
+                .learning-empty
+                  %strong 保存済み通知履歴はまだありません
+                  %p 今日の通知候補を履歴に保存すると、ここに追跡用のログが表示されます。

--- a/app/views/learning/teacher_dashboards/show.html.haml
+++ b/app/views/learning/teacher_dashboards/show.html.haml
@@ -60,6 +60,8 @@
       %h2 今、声かけしたい生徒
       .learning-section__actions
         %span.learning-notification-current= "通知設定：#{@notification_setting.delivery_channel_label}"
+        %span.learning-notification-current= "今日の通知候補：#{@notification_candidates_count}件"
+        %span.learning-notification-current= "保存済み履歴：#{@notification_logs_count}件"
         = link_to "通知設定を変更", edit_learning_notification_settings_path, class: "learning-button learning-button--ghost learning-button--sm"
         = link_to "通知ログを見る", learning_notifications_path, class: "learning-button learning-button--ghost learning-button--sm"
         = link_to "生徒一覧を見る", learning_students_path, class: "learning-button learning-button--ghost learning-button--sm"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -225,7 +225,9 @@ Rails.application.routes.draw do
     resource :teacher_dashboard, only: :show, controller: :teacher_dashboards do
       get :export_csv, on: :collection
     end
-    resources :notifications, only: :index
+    resources :notifications, only: :index do
+      post :persist_preview, on: :collection
+    end
     resource :notification_settings, only: [:edit, :update], controller: :notification_settings
     get "portal/:token", to: "student_portals#show", as: :student_portal
     post "portal/:token/complete_tutorial", to: "student_portals#complete_tutorial", as: :student_portal_complete_tutorial

--- a/db/migrate/20260509120000_create_learning_notification_logs.rb
+++ b/db/migrate/20260509120000_create_learning_notification_logs.rb
@@ -1,0 +1,30 @@
+class CreateLearningNotificationLogs < ActiveRecord::Migration[6.1]
+  def change
+    create_table :learning_notification_logs do |t|
+      t.references :customer, null: false, foreign_key: true, index: false
+      t.references :learning_student, null: true, foreign_key: true, index: false
+      t.string :notification_type, null: false
+      t.string :level
+      t.string :delivery_channel, null: false, default: "manual"
+      t.string :status, null: false, default: "previewed"
+      t.string :title
+      t.text :message, null: false
+      t.string :recommended_action
+      t.datetime :generated_at, null: false
+      t.datetime :sent_at
+      t.text :error_message
+      t.json :metadata
+
+      t.timestamps
+    end
+
+    add_index :learning_notification_logs, :customer_id
+    add_index :learning_notification_logs, :learning_student_id
+    add_index :learning_notification_logs, :notification_type
+    add_index :learning_notification_logs, :status
+    add_index :learning_notification_logs, :generated_at
+    add_index :learning_notification_logs,
+              [:customer_id, :learning_student_id, :notification_type, :generated_at],
+              name: "index_learning_notification_logs_on_daily_dedupe_lookup"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2026_05_09_010000) do
+ActiveRecord::Schema.define(version: 2026_05_09_120000) do
 
   create_table "active_admin_comments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "namespace"
@@ -431,6 +431,30 @@ ActiveRecord::Schema.define(version: 2026_05_09_010000) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["customer_id", "report_month"], name: "index_learning_monthly_reports_on_customer_and_month", unique: true
     t.index ["customer_id"], name: "index_learning_monthly_reports_on_customer_id"
+  end
+
+  create_table "learning_notification_logs", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "customer_id", null: false
+    t.bigint "learning_student_id"
+    t.string "notification_type", null: false
+    t.string "level"
+    t.string "delivery_channel", default: "manual", null: false
+    t.string "status", default: "previewed", null: false
+    t.string "title"
+    t.text "message", null: false
+    t.string "recommended_action"
+    t.datetime "generated_at", null: false
+    t.datetime "sent_at"
+    t.text "error_message"
+    t.json "metadata"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["customer_id", "learning_student_id", "notification_type", "generated_at"], name: "index_learning_notification_logs_on_daily_dedupe_lookup"
+    t.index ["customer_id"], name: "index_learning_notification_logs_on_customer_id"
+    t.index ["generated_at"], name: "index_learning_notification_logs_on_generated_at"
+    t.index ["learning_student_id"], name: "index_learning_notification_logs_on_learning_student_id"
+    t.index ["notification_type"], name: "index_learning_notification_logs_on_notification_type"
+    t.index ["status"], name: "index_learning_notification_logs_on_status"
   end
 
   create_table "learning_notification_settings", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
@@ -905,6 +929,8 @@ ActiveRecord::Schema.define(version: 2026_05_09_010000) do
   add_foreign_key "learning_effort_points", "customers"
   add_foreign_key "learning_effort_points", "learning_students"
   add_foreign_key "learning_monthly_reports", "customers"
+  add_foreign_key "learning_notification_logs", "customers"
+  add_foreign_key "learning_notification_logs", "learning_students"
   add_foreign_key "learning_notification_settings", "customers"
   add_foreign_key "learning_portal_accesses", "learning_students"
   add_foreign_key "learning_progress_logs", "customers"

--- a/spec/factories/learning_students.rb
+++ b/spec/factories/learning_students.rb
@@ -68,4 +68,18 @@ FactoryBot.define do
     student_reactivation_enabled { true }
     delivery_channel { "manual" }
   end
+
+  factory :learning_notification_log, class: "Learning::NotificationLog" do
+    customer
+    learning_student
+    notification_type { "reminder" }
+    level { "normal" }
+    delivery_channel { "manual" }
+    status { "previewed" }
+    title { "通知候補" }
+    message { "ここで戻ると差がつきます" }
+    recommended_action { "短い練習を選んで再開する" }
+    generated_at { Time.current }
+    metadata { { stage: 3, days_idle: 3 } }
+  end
 end

--- a/spec/models/learning/notification_log_spec.rb
+++ b/spec/models/learning/notification_log_spec.rb
@@ -1,0 +1,54 @@
+require "rails_helper"
+
+RSpec.describe Learning::NotificationLog, type: :model do
+  describe "associations" do
+    it "customer と learning_student に紐づくこと" do
+      log = build(:learning_notification_log)
+
+      expect(log.customer).to be_present
+      expect(log.learning_student).to be_present
+    end
+
+    it "learning_student は任意であること" do
+      log = build(:learning_notification_log, learning_student: nil)
+
+      expect(log).to be_valid
+    end
+  end
+
+  describe "validations" do
+    it "必須項目が揃っていれば有効であること" do
+      expect(build(:learning_notification_log)).to be_valid
+    end
+
+    it "customer は必須であること" do
+      log = build(:learning_notification_log, customer: nil)
+
+      expect(log).not_to be_valid
+    end
+
+    it "notification_type は許可された値のみ有効であること" do
+      log = build(:learning_notification_log, notification_type: "unknown")
+
+      expect(log).not_to be_valid
+    end
+
+    it "delivery_channel は必須であること" do
+      log = build(:learning_notification_log, delivery_channel: nil)
+
+      expect(log).not_to be_valid
+    end
+
+    it "status は必須であること" do
+      log = build(:learning_notification_log, status: nil)
+
+      expect(log).not_to be_valid
+    end
+
+    it "message は必須であること" do
+      log = build(:learning_notification_log, message: nil)
+
+      expect(log).not_to be_valid
+    end
+  end
+end

--- a/spec/requests/learning/notifications_spec.rb
+++ b/spec/requests/learning/notifications_spec.rb
@@ -16,9 +16,31 @@ RSpec.describe "Learning notifications", type: :request do
 
       expect(response).to have_http_status(:ok)
       expect(response.body).to include("現在の通知方式：手動コピー")
+      expect(response.body).to include("今日の通知候補を履歴に保存")
+      expect(response.body).to include("LINE/メール送信は準備中")
       expect(response.body).to include("ギターさん")
       expect(response.body).to include("5日")
       expect(response.body).to include("もう一度始めてみよう")
+    end
+
+    it "保存済み通知履歴を表示すること" do
+      student = create(:learning_student, customer: teacher, nickname: "ベースさん")
+      create(:learning_notification_log,
+             customer: teacher,
+             learning_student: student,
+             notification_type: "reminder",
+             level: "strong",
+             status: "previewed",
+             message: "もう一度始めてみよう",
+             recommended_action: "先生から声かけして再スタートする")
+
+      get learning_notifications_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("保存済み通知履歴")
+      expect(response.body).to include("ベースさん")
+      expect(response.body).to include("previewed")
+      expect(response.body).to include("先生から声かけして再スタートする")
     end
 
     it "生徒リマインド通知OFFなら通知候補を表示しないこと" do
@@ -32,6 +54,34 @@ RSpec.describe "Learning notifications", type: :request do
       expect(response).to have_http_status(:ok)
       expect(response.body).to include("生徒リマインド通知はOFFです")
       expect(response.body).not_to include("ギターさん")
+    end
+  end
+
+  describe "POST /learning/notifications/persist_preview" do
+    it "今日の通知候補を履歴に保存すること" do
+      student = create(:learning_student, customer: teacher, nickname: "ギターさん")
+      create(:learning_progress_log, customer: teacher, learning_student: student,
+                                    practiced_on: 5.days.ago.to_date)
+
+      expect {
+        post persist_preview_learning_notifications_path
+      }.to change(Learning::NotificationLog, :count).by(1)
+
+      expect(response).to redirect_to(learning_notifications_path)
+      expect(Learning::NotificationLog.last.learning_student).to eq(student)
+    end
+
+    it "生徒リマインド通知OFFなら履歴保存しないこと" do
+      create(:learning_notification_setting, customer: teacher, reminder_enabled: false)
+      student = create(:learning_student, customer: teacher, nickname: "ギターさん")
+      create(:learning_progress_log, customer: teacher, learning_student: student,
+                                    practiced_on: 5.days.ago.to_date)
+
+      expect {
+        post persist_preview_learning_notifications_path
+      }.not_to change(Learning::NotificationLog, :count)
+
+      expect(response).to redirect_to(learning_notifications_path)
     end
   end
 end

--- a/spec/services/learning/notification_dispatcher_spec.rb
+++ b/spec/services/learning/notification_dispatcher_spec.rb
@@ -25,16 +25,70 @@ RSpec.describe Learning::NotificationDispatcher do
     end
   end
 
+  describe "#persist_preview!" do
+    it "通知候補を通知履歴として保存すること" do
+      create(:learning_progress_log, customer: customer, learning_student: student,
+                                    practiced_on: 3.days.ago.to_date)
+
+      expect {
+        described_class.new(customer).persist_preview!
+      }.to change(Learning::NotificationLog, :count).by(1)
+
+      log = Learning::NotificationLog.last
+      expect(log.customer).to eq(customer)
+      expect(log.learning_student).to eq(student)
+      expect(log.notification_type).to eq("reminder")
+      expect(log.level).to eq("normal")
+      expect(log.status).to eq("previewed")
+      expect(log.delivery_channel).to eq("manual")
+      expect(log.message).to eq("ここで戻ると差がつきます")
+      expect(log.metadata["stage"]).to eq(3)
+    end
+
+    it "同日同種同生徒の通知履歴は重複保存しないこと" do
+      create(:learning_progress_log, customer: customer, learning_student: student,
+                                    practiced_on: 3.days.ago.to_date)
+
+      dispatcher = described_class.new(customer)
+
+      expect {
+        dispatcher.persist_preview!
+        dispatcher.persist_preview!
+      }.to change(Learning::NotificationLog, :count).by(1)
+    end
+
+    it "生徒リマインド通知OFFなら保存しないこと" do
+      create(:learning_notification_setting, customer: customer, reminder_enabled: false)
+      create(:learning_progress_log, customer: customer, learning_student: student,
+                                    practiced_on: 3.days.ago.to_date)
+
+      expect {
+        described_class.new(customer).persist_preview!
+      }.not_to change(Learning::NotificationLog, :count)
+    end
+  end
+
   describe "#dispatch" do
-    it "将来チャネル向けの planned delivery を返すこと" do
+    it "実送信せず、手動コピー設定では保存済み履歴を skipped にすること" do
       create(:learning_progress_log, customer: customer, learning_student: student,
                                     practiced_on: 5.days.ago.to_date)
 
-      deliveries = described_class.new(customer, channels: %i[line email unknown]).dispatch
+      logs = described_class.new(customer).dispatch
 
-      expect(deliveries.map(&:channel)).to eq(%i[line email])
-      expect(deliveries.map(&:status)).to eq(%i[planned planned])
-      expect(deliveries.first.reminder.student).to eq(student)
+      expect(logs.size).to eq(1)
+      expect(logs.first.status).to eq("skipped")
+    end
+
+    it "LINE/メール設定では将来送信用に queued にすること" do
+      create(:learning_notification_setting, customer: customer, delivery_channel: "line")
+      create(:learning_progress_log, customer: customer, learning_student: student,
+                                    practiced_on: 5.days.ago.to_date)
+
+      logs = described_class.new(customer).dispatch
+
+      expect(logs.size).to eq(1)
+      expect(logs.first.status).to eq("queued")
+      expect(logs.first.delivery_channel).to eq("line")
     end
   end
 end


### PR DESCRIPTION
## 概要
LINE/メール実配信前の準備として、Learning通知候補・通知履歴をDB保存できる仕組みを追加しました。

## 変更内容
- `learning_notification_logs` テーブルを追加
- `Learning::NotificationLog` モデルを追加
- `NotificationDispatcher#persist_preview!` を追加
- 同日同種同生徒の重複保存を抑制
- `/learning/notifications` に今日の通知候補・保存済み通知履歴を表示
- 顧問ダッシュボードに通知候補数・保存済み履歴数を表示

## 確認済み
- `DISABLE_SPRING=1 bundle exec rails runner 'puts "boot ok"'`
- `DISABLE_SPRING=1 bundle exec rspec spec/models/learning spec/services/learning spec/requests/learning`
- `RAILS_ENV=production bundle exec rails assets:precompile`
- `git diff --check`
- `git status --short public/assets public/packs`

## 注意点
- DB migration あり
- 実送信は未実装
- LINE/メールはまだ準備中
- 本番反映時に migration 実行確認必須