### PR TITLE
feat: Phase34 レビュー履歴機能を追加

### DIFF
--- a/app/controllers/learning/assignments_controller.rb
+++ b/app/controllers/learning/assignments_controller.rb
@@ -90,7 +90,7 @@ class Learning::AssignmentsController < Learning::BaseController
     @assignment = current_customer.learning_assignments
       .includes(:learning_student, learning_student_training: :learning_training_master)
       .find(params[:id])
-    @assignments = assignment_group_for(@assignment)
+    @assignments = assignment_group_for(@assignment, includes_review_histories: true)
     @assignment_summary = AssignmentSummary.new(representative: @assignment, assignments: @assignments)
     @student_progresses = filtered_student_progresses(@assignments)
     @reminder_message = DEFAULT_REMINDER_MESSAGE
@@ -284,8 +284,10 @@ class Learning::AssignmentsController < Learning::BaseController
       .reverse
   end
 
-  def assignment_group_for(assignment)
-    scope = current_customer.learning_assignments.includes(:learning_student, learning_student_training: :learning_training_master)
+  def assignment_group_for(assignment, includes_review_histories: false)
+    base_includes = [:learning_student, { learning_student_training: :learning_training_master }]
+    base_includes << :review_histories if includes_review_histories
+    scope = current_customer.learning_assignments.includes(base_includes)
     if assignment.assignment_group_key.present?
       scope.where(assignment_group_key: assignment.assignment_group_key).order(:created_at, :id).to_a
     else

--- a/app/controllers/learning/student_portals_controller.rb
+++ b/app/controllers/learning/student_portals_controller.rb
@@ -25,12 +25,13 @@ class Learning::StudentPortalsController < ApplicationController
     }
     @current_trainings = trainings.first(8)
     @weekly_training_assignments = @student.learning_assignments
-      .includes(learning_student_training: :learning_training_master)
+      .includes(:review_histories, learning_student_training: :learning_training_master)
       .where(status: LearningAssignment::ACTION_REQUIRED_STATUSES)
       .where.not(learning_student_training_id: nil)
       .recent_first
       .limit(8)
     @current_assignments = @student.learning_assignments
+      .includes(:review_histories)
       .where(status: LearningAssignment::ACTION_REQUIRED_STATUSES)
       .recent_first
       .limit(5)

--- a/app/controllers/learning/teacher_dashboards_controller.rb
+++ b/app/controllers/learning/teacher_dashboards_controller.rb
@@ -36,7 +36,7 @@ class Learning::TeacherDashboardsController < Learning::BaseController
       .completed_recent_first
       .limit(5)
     @pending_review_assignments = current_customer.learning_assignments
-      .includes(:learning_student, learning_student_training: :learning_training_master)
+      .includes(:learning_student, :review_histories, learning_student_training: :learning_training_master)
       .where(learning_student_id: @students.map(&:id))
       .where(status: "pending_review")
       .select { |assignment| assignment.learning_student_training&.teacher_judged? }

--- a/app/models/learning_assignment.rb
+++ b/app/models/learning_assignment.rb
@@ -8,6 +8,7 @@ class LearningAssignment < ApplicationRecord
   belongs_to :learning_student
   belongs_to :learning_student_training, optional: true
   belongs_to :reviewed_by, class_name: "Customer", optional: true
+  has_many :review_histories, class_name: "LearningAssignmentReviewHistory", dependent: :destroy
 
   validates :title, presence: true, length: { maximum: 100 }
   validates :description, length: { maximum: 1000 }, allow_blank: true
@@ -70,11 +71,14 @@ class LearningAssignment < ApplicationRecord
   end
 
   def mark_submitted_for_review!(message: nil, time: Time.current)
-    update!(
-      status: "pending_review",
-      submitted_at: time,
-      reaction_message: message.to_s.presence&.truncate(255)
-    )
+    transaction do
+      update!(
+        status: "pending_review",
+        submitted_at: time,
+        reaction_message: message.to_s.presence&.truncate(255)
+      )
+      add_review_history!(action: "submitted", submitted_at: time)
+    end
   end
 
   def approve_review!(reviewer:, comment: nil, time: Time.current)
@@ -92,6 +96,7 @@ class LearningAssignment < ApplicationRecord
         review_comment: comment.to_s.presence
       )
       create_progress_log_from_review!
+      add_review_history!(action: "approved", reviewer: reviewer, comment: comment.to_s.presence, reviewed_at: time)
     end
   end
 
@@ -101,11 +106,32 @@ class LearningAssignment < ApplicationRecord
       raise ActiveRecord::RecordInvalid, self
     end
 
-    update!(
-      status: "needs_revision",
-      reviewed_at: time,
-      reviewed_by: reviewer,
-      review_comment: comment.to_s.presence
+    transaction do
+      update!(
+        status: "needs_revision",
+        reviewed_at: time,
+        reviewed_by: reviewer,
+        review_comment: comment.to_s.presence
+      )
+      add_review_history!(action: "revision_requested", reviewer: reviewer, comment: comment.to_s.presence, reviewed_at: time)
+    end
+  end
+
+  def revision_count
+    review_histories.where(action: "revision_requested").count
+  end
+
+  def last_revision_comment
+    review_histories.where(action: "revision_requested").order(created_at: :desc).first&.comment
+  end
+
+  def add_review_history!(action:, reviewer: nil, comment: nil, submitted_at: nil, reviewed_at: nil)
+    review_histories.create!(
+      action: action,
+      reviewer: reviewer,
+      comment: comment,
+      submitted_at: submitted_at,
+      reviewed_at: reviewed_at
     )
   end
 

--- a/app/models/learning_assignment_review_history.rb
+++ b/app/models/learning_assignment_review_history.rb
@@ -1,0 +1,33 @@
+class LearningAssignmentReviewHistory < ApplicationRecord
+  ACTIONS = %w[submitted approved revision_requested].freeze
+
+  ACTION_LABELS = {
+    "submitted" => "生徒が提出",
+    "approved" => "先生が承認",
+    "revision_requested" => "先生が差し戻し"
+  }.freeze
+
+  belongs_to :learning_assignment
+  belongs_to :reviewer, class_name: "Customer", optional: true
+
+  validates :action, presence: true, inclusion: { in: ACTIONS }
+
+  scope :chronological, -> { order(created_at: :asc) }
+  scope :reverse_chronological, -> { order(created_at: :desc) }
+
+  def action_label
+    ACTION_LABELS.fetch(action, action)
+  end
+
+  def submitted?
+    action == "submitted"
+  end
+
+  def approved?
+    action == "approved"
+  end
+
+  def revision_requested?
+    action == "revision_requested"
+  end
+end

--- a/app/services/learning/analytics_report.rb
+++ b/app/services/learning/analytics_report.rb
@@ -18,6 +18,8 @@ module Learning
       :needs_revision_count,
       :line_sent_count,
       :line_reaction_count,
+      :revision_request_count,
+      :average_revision_count,
       keyword_init: true
     )
 
@@ -90,7 +92,9 @@ module Learning
         pending_review_count: assignments.count { |assignment| assignment.status == "pending_review" },
         needs_revision_count: assignments.count { |assignment| assignment.status == "needs_revision" },
         line_sent_count: line_sent_logs.count,
-        line_reaction_count: line_reaction_logs.count
+        line_reaction_count: line_reaction_logs.count,
+        revision_request_count: revision_request_count,
+        average_revision_count: average_revision_count
       )
     end
 
@@ -307,6 +311,24 @@ module Learning
         watch: "様子見",
         follow_up: "要フォロー"
       }.fetch(status)
+    end
+
+    def revision_request_count
+      @revision_request_count ||= LearningAssignmentReviewHistory
+        .where(learning_assignment_id: assignments.map(&:id), action: "revision_requested")
+        .count
+    end
+
+    def average_revision_count
+      @average_revision_count ||= begin
+        assignment_ids_with_revision = LearningAssignmentReviewHistory
+          .where(learning_assignment_id: assignments.map(&:id), action: "revision_requested")
+          .distinct
+          .pluck(:learning_assignment_id)
+        return 0.0 if assignment_ids_with_revision.empty?
+
+        (revision_request_count.to_f / assignment_ids_with_revision.size).round(1)
+      end
     end
 
     def percentage(numerator, denominator)

--- a/app/services/learning/auto_reminder_service.rb
+++ b/app/services/learning/auto_reminder_service.rb
@@ -148,9 +148,13 @@ module Learning
     end
 
     def assignment_reminder_message(assignment, student, notification_type)
-      return FALLBACK_MESSAGES.fetch("needs_revision") if assignment.needs_revision?
-
-      template_body_for(student, notification_type) || FALLBACK_MESSAGES.fetch(notification_type)
+      if assignment.needs_revision?
+        base = FALLBACK_MESSAGES.fetch("needs_revision")
+        last_comment = assignment.last_revision_comment
+        last_comment.present? ? "#{base}\n先生コメント：#{last_comment.truncate(100)}" : base
+      else
+        template_body_for(student, notification_type) || FALLBACK_MESSAGES.fetch(notification_type)
+      end
     end
 
     def build_candidate(student:, notification_type:, reason:, title:, message:, recommended_action:, level:, assignment: nil)
@@ -234,6 +238,7 @@ module Learning
 
     def open_assignments
       @open_assignments ||= @customer.learning_assignments
+        .includes(:review_histories)
         .where(status: LearningAssignment::ACTION_REQUIRED_STATUSES, learning_student_id: line_connected_students.map(&:id))
     end
 

--- a/app/views/learning/assignments/show.html.haml
+++ b/app/views/learning/assignments/show.html.haml
@@ -114,6 +114,15 @@
                       = "先生確認済み: #{l(progress.assignment.reviewed_at, format: :short)}"
                     - if progress.assignment.review_comment.present?
                       %div.learning-muted= "コメント: #{progress.assignment.review_comment}"
+                  - histories = progress.assignment.review_histories.sort_by(&:created_at)
+                  - if histories.any?
+                    .learning-review-timeline
+                      - histories.each do |history|
+                        .learning-review-timeline__item{ class: "learning-review-timeline__item--#{history.action.dasherize}" }
+                          %span.learning-review-timeline__date= l(history.created_at, format: :short)
+                          %span.learning-review-timeline__label= history.action_label
+                          - if history.comment.present?
+                            %span.learning-review-timeline__comment= history.comment
                 %td= progress.assignment.due_on ? progress.assignment.due_on.strftime("%-m/%-d") : "-"
                 %td
                   - if progress.last_reaction_log

--- a/app/views/learning/student_portals/show.html.haml
+++ b/app/views/learning/student_portals/show.html.haml
@@ -121,6 +121,18 @@
                 - elsif assignment.pending_review?
                   .learning-detail-card
                     %p 先生確認待ちです
+                - histories = assignment.review_histories.sort_by(&:created_at)
+                - if histories.size > 1
+                  .learning-detail-card
+                    %p
+                      %strong チャレンジ履歴
+                    .learning-review-timeline.learning-review-timeline--compact
+                      - histories.each do |history|
+                        .learning-review-timeline__item{ class: "learning-review-timeline__item--#{history.action.dasherize}" }
+                          %span.learning-review-timeline__date= history.created_at.strftime("%-m/%-d")
+                          %span.learning-review-timeline__label= history.action_label
+                          - if history.comment.present?
+                            %span.learning-review-timeline__comment= history.comment
                 - if training
                   .learning-detail-card
                     - if training.check_method.present?

--- a/app/views/learning/teacher_dashboards/show.html.haml
+++ b/app/views/learning/teacher_dashboards/show.html.haml
@@ -297,6 +297,8 @@
       .learning-stack
         - @pending_review_assignments.each do |assignment|
           - training = assignment.learning_student_training
+          - revision_cnt = assignment.revision_count
+          - last_rev_comment = assignment.last_revision_comment
           .learning-review-row
             %div
               %strong= "#{assignment.learning_student.display_name} / #{training&.title || assignment.title}"
@@ -304,6 +306,8 @@
                 = assignment.submitted_at ? "報告日時: #{l(assignment.submitted_at, format: :short)}" : "報告日時: -"
                 - if training&.judge_type_label.present?
                   = " / #{training.judge_type_label}"
+              - if revision_cnt.positive?
+                %span.learning-muted= "差し戻し #{revision_cnt}回 / 前回コメント: #{last_rev_comment.presence || 'なし'}"
               - if training&.check_method.present?
                 %span= "確認方法: #{training.check_method}"
               - if training&.achievement_criteria.present?

--- a/db/migrate/20260511143322_create_learning_assignment_review_histories.rb
+++ b/db/migrate/20260511143322_create_learning_assignment_review_histories.rb
@@ -1,0 +1,19 @@
+class CreateLearningAssignmentReviewHistories < ActiveRecord::Migration[6.1]
+  def change
+    create_table :learning_assignment_review_histories do |t|
+      t.references :learning_assignment, null: false,
+                   foreign_key: true,
+                   index: { name: "idx_review_hist_on_assignment_id" }
+      t.references :reviewer, foreign_key: { to_table: :customers }, null: true,
+                   index: { name: "idx_review_hist_on_reviewer_id" }
+      t.string :action, null: false
+      t.text :comment
+      t.datetime :submitted_at
+      t.datetime :reviewed_at
+      t.timestamps
+    end
+
+    add_index :learning_assignment_review_histories, [:learning_assignment_id, :created_at],
+              name: "idx_review_hist_on_assignment_and_created_at"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2026_05_11_060000) do
+ActiveRecord::Schema.define(version: 2026_05_11_143322) do
 
   create_table "active_admin_comments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "namespace"
@@ -358,6 +358,20 @@ ActiveRecord::Schema.define(version: 2026_05_11_060000) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["song_id"], name: "index_join_parts_on_song_id"
+  end
+
+  create_table "learning_assignment_review_histories", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "learning_assignment_id", null: false
+    t.bigint "reviewer_id"
+    t.string "action", null: false
+    t.text "comment"
+    t.datetime "submitted_at"
+    t.datetime "reviewed_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["learning_assignment_id", "created_at"], name: "idx_review_hist_on_assignment_and_created_at"
+    t.index ["learning_assignment_id"], name: "idx_review_hist_on_assignment_id"
+    t.index ["reviewer_id"], name: "idx_review_hist_on_reviewer_id"
   end
 
   create_table "learning_assignments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
@@ -995,6 +1009,8 @@ ActiveRecord::Schema.define(version: 2026_05_11_060000) do
   add_foreign_key "join_part_customers", "customers"
   add_foreign_key "join_part_customers", "join_parts"
   add_foreign_key "join_parts", "songs"
+  add_foreign_key "learning_assignment_review_histories", "customers", column: "reviewer_id"
+  add_foreign_key "learning_assignment_review_histories", "learning_assignments"
   add_foreign_key "learning_assignments", "customers"
   add_foreign_key "learning_assignments", "customers", column: "reviewed_by_id"
   add_foreign_key "learning_assignments", "learning_student_trainings"

--- a/spec/factories/learning_students.rb
+++ b/spec/factories/learning_students.rb
@@ -117,6 +117,12 @@ FactoryBot.define do
     metadata { { source: "spec" } }
   end
 
+  factory :learning_assignment_review_history do
+    learning_assignment
+    action { "submitted" }
+    comment { nil }
+  end
+
   factory :learning_line_message_template do
     customer
     title { "要フォロー" }

--- a/spec/models/learning_assignment_review_history_spec.rb
+++ b/spec/models/learning_assignment_review_history_spec.rb
@@ -1,0 +1,91 @@
+require "rails_helper"
+
+RSpec.describe LearningAssignmentReviewHistory, type: :model do
+  let!(:learning_domain) { Domain.find_or_create_by!(name: "learning") }
+  let(:teacher) { create(:customer, domain_name: "learning", confirmed_at: Time.current) }
+  let(:assignment) { create(:learning_assignment, customer: teacher) }
+
+  describe "バリデーション" do
+    it "actionがsubmittedで有効なこと" do
+      history = assignment.review_histories.build(action: "submitted")
+      expect(history).to be_valid
+    end
+
+    it "actionがapprovedで有効なこと" do
+      history = assignment.review_histories.build(action: "approved")
+      expect(history).to be_valid
+    end
+
+    it "actionがrevision_requestedで有効なこと" do
+      history = assignment.review_histories.build(action: "revision_requested")
+      expect(history).to be_valid
+    end
+
+    it "無効なactionは保存できないこと" do
+      history = assignment.review_histories.build(action: "invalid_action")
+      expect(history).not_to be_valid
+      expect(history.errors[:action]).to be_present
+    end
+
+    it "actionが空の場合は保存できないこと" do
+      history = assignment.review_histories.build(action: nil)
+      expect(history).not_to be_valid
+    end
+  end
+
+  describe "スコープ" do
+    it "chronologicalで古い順に並ぶこと" do
+      old = assignment.review_histories.create!(action: "submitted", created_at: 2.hours.ago)
+      new_history = assignment.review_histories.create!(action: "revision_requested", created_at: 1.hour.ago)
+
+      result = assignment.review_histories.chronological.to_a
+      expect(result.first).to eq(old)
+      expect(result.last).to eq(new_history)
+    end
+
+    it "reverse_chronologicalで新しい順に並ぶこと" do
+      old = assignment.review_histories.create!(action: "submitted", created_at: 2.hours.ago)
+      new_history = assignment.review_histories.create!(action: "approved", created_at: 1.hour.ago)
+
+      result = assignment.review_histories.reverse_chronological.to_a
+      expect(result.first).to eq(new_history)
+      expect(result.last).to eq(old)
+    end
+  end
+
+  describe "action_label" do
+    it "submittedは生徒が提出と返すこと" do
+      history = build(:learning_assignment_review_history, action: "submitted")
+      expect(history.action_label).to eq("生徒が提出")
+    end
+
+    it "approvedは先生が承認と返すこと" do
+      history = build(:learning_assignment_review_history, action: "approved")
+      expect(history.action_label).to eq("先生が承認")
+    end
+
+    it "revision_requestedは先生が差し戻しと返すこと" do
+      history = build(:learning_assignment_review_history, action: "revision_requested")
+      expect(history.action_label).to eq("先生が差し戻し")
+    end
+  end
+
+  describe "reviewer保存" do
+    it "reviewerが保存されること" do
+      history = assignment.review_histories.create!(action: "approved", reviewer: teacher)
+      expect(history.reload.reviewer).to eq(teacher)
+    end
+
+    it "reviewerはnilでも保存できること" do
+      history = assignment.review_histories.create!(action: "submitted")
+      expect(history.reload.reviewer).to be_nil
+    end
+  end
+
+  describe "comment保存" do
+    it "コメントが保存されること" do
+      history = assignment.review_histories.create!(action: "revision_requested", comment: "テンポを確認してみよう")
+      expect(history.reload.comment).to eq("テンポを確認してみよう")
+    end
+  end
+end

--- a/spec/requests/learning/assignments_show_spec.rb
+++ b/spec/requests/learning/assignments_show_spec.rb
@@ -153,6 +153,7 @@ RSpec.describe "Learning assignment show", type: :request do
         patch approve_review_learning_assignment_path(assignment),
               params: { review_comment: "確認しました" }
       }.to change(LearningProgressLog, :count).by(1)
+           .and change(LearningAssignmentReviewHistory, :count).by(1)
 
       assignment.reload
       expect(response).to redirect_to(learning_teacher_dashboard_path)
@@ -160,6 +161,11 @@ RSpec.describe "Learning assignment show", type: :request do
       expect(assignment.reviewed_by).to eq(teacher)
       expect(assignment.review_comment).to eq("確認しました")
       expect(assignment.reviewed_at).to be_present
+
+      history = LearningAssignmentReviewHistory.last
+      expect(history.action).to eq("approved")
+      expect(history.reviewer).to eq(teacher)
+      expect(history.comment).to eq("確認しました")
     end
 
     it "他顧問のassignmentは承認できないこと" do
@@ -194,6 +200,7 @@ RSpec.describe "Learning assignment show", type: :request do
           patch request_revision_learning_assignment_path(assignment),
                 params: { review_comment: "テンポ80で再チャレンジしてみよう" }
         }.to change(Learning::NotificationLog, :count).by(1)
+           .and change(LearningAssignmentReviewHistory, :count).by(1)
       }.not_to change(LearningProgressLog, :count)
 
       assignment.reload
@@ -203,6 +210,11 @@ RSpec.describe "Learning assignment show", type: :request do
       expect(assignment.review_comment).to eq("テンポ80で再チャレンジしてみよう")
       expect(assignment.reviewed_at).to be_present
       expect(Learning::NotificationLog.last.notification_type).to eq("teacher_revision_request")
+
+      history = LearningAssignmentReviewHistory.last
+      expect(history.action).to eq("revision_requested")
+      expect(history.reviewer).to eq(teacher)
+      expect(history.comment).to eq("テンポ80で再チャレンジしてみよう")
     end
 
     it "他顧問のassignmentは差し戻しできないこと" do

--- a/spec/requests/learning/student_portals_spec.rb
+++ b/spec/requests/learning/student_portals_spec.rb
@@ -46,4 +46,23 @@ RSpec.describe "Learning student portals", type: :request do
     expect(response.body).to include("テンポ80で再チャレンジしてみよう")
     expect(response.body).to include("できたらLINEで「やった」と返信しよう")
   end
+
+  it "複数のレビュー履歴がある課題にチャレンジ履歴を表示すること" do
+    training = create(:learning_student_training,
+                      customer: teacher,
+                      learning_student: student)
+    assignment = training.learning_assignments.first
+    assignment.update!(status: "needs_revision", review_comment: "メトロノームで再チャレンジ")
+    assignment.review_histories.create!(action: "submitted", created_at: 3.days.ago)
+    assignment.review_histories.create!(action: "revision_requested",
+                                        comment: "メトロノームで再チャレンジ",
+                                        created_at: 2.days.ago)
+
+    get learning_student_portal_path(student.public_access_token)
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include("チャレンジ履歴")
+    expect(response.body).to include("生徒が提出")
+    expect(response.body).to include("先生が差し戻し")
+  end
 end

--- a/spec/requests/learning/teacher_dashboards_spec.rb
+++ b/spec/requests/learning/teacher_dashboards_spec.rb
@@ -65,4 +65,48 @@ RSpec.describe "Learning teacher dashboards", type: :request do
     expect(response.body).to include("改善コメントを書く例")
     expect(response.body).to include("テンポを崩さず最後までできたら達成")
   end
+
+  it "差し戻し履歴がある課題には差し戻し回数と前回コメントを表示すること" do
+    student = create(:learning_student, customer: teacher)
+    master = create(:learning_training_master,
+                    customer: teacher,
+                    judge_type: "teacher")
+    training = create(:learning_student_training,
+                      customer: teacher,
+                      learning_student: student,
+                      learning_training_master: master,
+                      title: nil)
+    assignment = training.learning_assignments.first
+    assignment.update!(status: "pending_review", submitted_at: Time.current)
+    assignment.review_histories.create!(action: "revision_requested",
+                                        reviewer: teacher,
+                                        comment: "テンポを80に合わせてみよう")
+
+    get learning_teacher_dashboard_path
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include("差し戻し 1回")
+    expect(response.body).to include("テンポを80に合わせてみよう")
+  end
+
+  it "他顧問の履歴は表示されないこと" do
+    other_teacher = create(:customer, domain_name: "learning", confirmed_at: Time.current)
+    other_student = create(:learning_student, customer: other_teacher)
+    other_master = create(:learning_training_master, customer: other_teacher, judge_type: "teacher")
+    other_training = create(:learning_student_training,
+                            customer: other_teacher,
+                            learning_student: other_student,
+                            learning_training_master: other_master,
+                            title: nil)
+    other_assignment = other_training.learning_assignments.first
+    other_assignment.update!(status: "pending_review", submitted_at: Time.current)
+    other_assignment.review_histories.create!(action: "revision_requested",
+                                              reviewer: other_teacher,
+                                              comment: "他顧問のコメント")
+
+    get learning_teacher_dashboard_path
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).not_to include("他顧問のコメント")
+  end
 end

--- a/spec/services/learning/analytics_report_spec.rb
+++ b/spec/services/learning/analytics_report_spec.rb
@@ -92,6 +92,27 @@ RSpec.describe Learning::AnalyticsReport do
       expect(report.summary.unsubmitted_count).to eq(1)
       expect(report.summary.needs_revision_count).to eq(1)
     end
+
+    it "差し戻し回数と平均差し戻し回数を算出できること" do
+      assignment1 = create(:learning_assignment, customer: customer, learning_student: student,
+                                                 status: "completed", completed_at: reference_time)
+      assignment2 = create(:learning_assignment, customer: customer, learning_student: student,
+                                                 status: "needs_revision", created_at: reference_time)
+      assignment1.review_histories.create!(action: "revision_requested", created_at: reference_time - 1.day)
+      assignment1.review_histories.create!(action: "revision_requested", created_at: reference_time - 12.hours)
+      assignment2.review_histories.create!(action: "revision_requested", created_at: reference_time)
+
+      expect(report.summary.revision_request_count).to eq(3)
+      expect(report.summary.average_revision_count).to eq(1.5)
+    end
+
+    it "差し戻し履歴なしの場合は0を返すこと" do
+      create(:learning_assignment, customer: customer, learning_student: student,
+                                   status: "completed", completed_at: reference_time)
+
+      expect(report.summary.revision_request_count).to eq(0)
+      expect(report.summary.average_revision_count).to eq(0.0)
+    end
   end
 
   describe "#student_summaries" do


### PR DESCRIPTION
- LearningAssignmentReviewHistory モデル・テーブルを新規追加 (action: submitted / approved / revision_requested)
- LearningAssignment に has_many :review_histories を追加
- mark_submitted_for_review! / approve_review! / request_revision! で 自動的に履歴を保存する add_review_history! を実装
- LearningAssignment に revision_count / last_revision_comment メソッドを追加
- 課題詳細・生徒ポータル・顧問ダッシュボードに時系列履歴を表示
- 顧問ダッシュボードの承認待ち一覧に差し戻し回数・前回コメントを表示
- AnalyticsReport に revision_request_count / average_revision_count を追加
- AutoReminderService で needs_revision 時に前回教師コメントを通知に含める
- 各コントローラーで review_histories を includes し N+1 を防止