### PR TITLE
feat: Phase35 差し戻し多発トレーニング分析ダッシュボードを追加

### DIFF
--- a/app/controllers/learning/teacher_dashboards_controller.rb
+++ b/app/controllers/learning/teacher_dashboards_controller.rb
@@ -20,6 +20,7 @@ class Learning::TeacherDashboardsController < Learning::BaseController
     @onboarding_checklist = Learning::OnboardingChecklist.new(current_customer, routes: self)
     @teacher_next_action = Learning::FirstDayExperience.teacher_action(current_customer, routes: self)
     @analytics_report = Learning::AnalyticsReport.new(current_customer, period: params[:period], students: @students)
+    @revision_analysis = Learning::RevisionAnalysisReport.new(current_customer)
     @line_message_templates = current_customer.learning_line_message_templates.active.ordered
     @weekly_growth = build_weekly_growth
     @weekly_assignment_status = build_weekly_assignment_status

--- a/app/services/learning/revision_analysis_report.rb
+++ b/app/services/learning/revision_analysis_report.rb
@@ -1,0 +1,143 @@
+module Learning
+  class RevisionAnalysisReport
+    TROUBLED_TRAINING_LIMIT = 5
+    STRUGGLING_STUDENT_LIMIT = 5
+    RECENT_REVISIONS_LIMIT = 10
+
+    IMPROVEMENT_HINT = "差し戻しが多い場合、達成基準やチェック方法を具体化しましょう。".freeze
+    FOLLOWUP_HINT = "個別に声をかけて、どこで止まっているか確認しましょう。".freeze
+
+    TroubledTraining = Struct.new(
+      :training_title,
+      :revision_count,
+      :student_count,
+      :latest_comment,
+      :improvement_hint,
+      keyword_init: true
+    )
+
+    StrugglingStudent = Struct.new(
+      :student,
+      :revision_count,
+      :training_count,
+      :last_revised_at,
+      :followup_hint,
+      keyword_init: true
+    )
+
+    RecentRevision = Struct.new(
+      :history,
+      :student,
+      :training_title,
+      :assignment,
+      keyword_init: true
+    )
+
+    def initialize(customer)
+      @customer = customer
+    end
+
+    def troubled_trainings
+      @troubled_trainings ||= build_troubled_trainings
+    end
+
+    def struggling_students
+      @struggling_students ||= build_struggling_students
+    end
+
+    def recent_revisions
+      @recent_revisions ||= build_recent_revisions
+    end
+
+    def any_data?
+      revision_histories.any?
+    end
+
+    private
+
+    def revision_histories
+      @revision_histories ||= LearningAssignmentReviewHistory
+        .where(learning_assignment_id: customer_assignment_ids, action: "revision_requested")
+        .includes(learning_assignment: [:learning_student, { learning_student_training: :learning_training_master }])
+        .order(created_at: :desc)
+        .to_a
+    end
+
+    def customer_assignment_ids
+      @customer.learning_assignments.select(:id)
+    end
+
+    def build_troubled_trainings
+      training_groups = revision_histories
+        .select { |h| h.learning_assignment.learning_student_training_id.present? }
+        .group_by { |h| training_group_key(h) }
+
+      training_groups.map do |_key, histories|
+        training = histories.first.learning_assignment.learning_student_training
+        training_title = training.title.presence || "タイトルなし"
+        student_ids = histories.map { |h| h.learning_assignment.learning_student_id }.uniq
+        latest_comment = histories.find { |h| h.comment.present? }&.comment
+
+        TroubledTraining.new(
+          training_title: training_title,
+          revision_count: histories.size,
+          student_count: student_ids.size,
+          latest_comment: latest_comment,
+          improvement_hint: IMPROVEMENT_HINT
+        )
+      end
+        .sort_by { |item| [-item.revision_count, item.training_title.to_s] }
+        .first(TROUBLED_TRAINING_LIMIT)
+    end
+
+    def training_group_key(history)
+      training = history.learning_assignment.learning_student_training
+      master_id = training.learning_training_master_id
+      master_id.present? ? "master-#{master_id}" : "training-#{training.id}"
+    end
+
+    def build_struggling_students
+      student_groups = revision_histories.group_by do |h|
+        h.learning_assignment.learning_student_id
+      end
+
+      student_groups.map do |_student_id, histories|
+        student = histories.first.learning_assignment.learning_student
+        training_ids = histories
+          .map { |h| h.learning_assignment.learning_student_training_id }
+          .compact
+          .uniq
+        last_revised_at = histories.map(&:created_at).max
+
+        StrugglingStudent.new(
+          student: student,
+          revision_count: histories.size,
+          training_count: training_ids.size,
+          last_revised_at: last_revised_at,
+          followup_hint: FOLLOWUP_HINT
+        )
+      end
+        .sort_by { |item| [-item.revision_count, item.student.display_name.to_s] }
+        .first(STRUGGLING_STUDENT_LIMIT)
+    end
+
+    def build_recent_revisions
+      revision_histories
+        .select { |h| h.comment.present? }
+        .first(RECENT_REVISIONS_LIMIT)
+        .map do |history|
+          assignment = history.learning_assignment
+          student = assignment.learning_student
+          training = assignment.learning_student_training
+          training_title = training&.title.presence || assignment.title
+
+          RecentRevision.new(
+            history: history,
+            student: student,
+            training_title: training_title,
+            assignment: assignment
+          )
+        end
+    end
+  end
+end

--- a/app/views/learning/teacher_dashboards/show.html.haml
+++ b/app/views/learning/teacher_dashboards/show.html.haml
@@ -553,6 +553,83 @@
                   %p 生徒を登録すると、専用ポータルURL・課題割当・努力ポイントの運用を始められます。
                   = link_to "生徒を追加", new_learning_student_path, class: "learning-button"
 
+  .learning-section
+    .learning-section__header
+      %h2 指導改善ヒント
+      %span.learning-notification-current 差し戻し分析（全期間）
+    - if @revision_analysis.any_data?
+      - if @revision_analysis.troubled_trainings.any?
+        .learning-revision-panel
+          .learning-section__header
+            %h3 重点フォロー候補のトレーニング
+            %p.learning-muted 再チャレンジが多いトレーニングです。達成基準やチェック方法の見直しが効果的かもしれません。
+          .learning-table-wrap
+            %table.learning-table
+              %thead
+                %tr
+                  %th トレーニング名
+                  %th.text-right 差し戻し回数
+                  %th.text-right 対象生徒
+                  %th 直近コメント
+                  %th 改善ヒント
+              %tbody
+                - @revision_analysis.troubled_trainings.each do |item|
+                  %tr
+                    %td= item.training_title
+                    %td.text-right
+                      %strong= "#{item.revision_count}回"
+                    %td.text-right= "#{item.student_count}名"
+                    %td
+                      - if item.latest_comment.present?
+                        %span.learning-muted= item.latest_comment.truncate(60)
+                      - else
+                        %span.learning-muted コメントなし
+                    %td
+                      %small.learning-muted= item.improvement_hint
+
+      - if @revision_analysis.struggling_students.any?
+        .learning-revision-panel
+          .learning-section__header
+            %h3 重点フォロー候補の生徒
+            %p.learning-muted 再チャレンジが多い生徒です。個別に話しかけてどこで止まっているか確認してみましょう。
+          .learning-table-wrap
+            %table.learning-table
+              %thead
+                %tr
+                  %th 生徒
+                  %th.text-right 差し戻し回数
+                  %th.text-right 対象トレーニング
+                  %th 最終差し戻し日
+                  %th フォロー提案
+              %tbody
+                - @revision_analysis.struggling_students.each do |item|
+                  %tr
+                    %td= link_to item.student.display_name, learning_student_path(item.student)
+                    %td.text-right
+                      %strong= "#{item.revision_count}回"
+                    %td.text-right= "#{item.training_count}件"
+                    %td= l(item.last_revised_at, format: :short)
+                    %td
+                      %small.learning-muted= item.followup_hint
+
+      - if @revision_analysis.recent_revisions.any?
+        .learning-revision-panel
+          .learning-section__header
+            %h3 最近の差し戻しコメント
+            %p.learning-muted 直近の差し戻し内容です。繰り返し出るテーマは説明を工夫するチャンスかもしれません。
+          .learning-stack
+            - @revision_analysis.recent_revisions.each do |rev|
+              .learning-review-row
+                %div
+                  %strong= "#{rev.student.display_name} / #{rev.training_title}"
+                  %span.learning-muted= l(rev.history.created_at, format: :short)
+                %p= rev.history.comment
+                = link_to "課題詳細", learning_assignment_path(rev.assignment), class: "learning-button learning-button--ghost learning-button--sm"
+    - else
+      .learning-empty
+        %strong まだ差し戻し履歴はありません。順調に進んでいます。
+        %p 生徒が課題を提出して先生が確認すると、差し戻し分析がここに表示されます。
+
   .learning-assurance
     %strong 安心して運用するために
     %p 生徒はニックネームで運用できます。ランキングは個人を責めるためではなく、努力・継続・成長を部活動全体で見守るための仕組みです。

--- a/spec/requests/learning/teacher_dashboards_spec.rb
+++ b/spec/requests/learning/teacher_dashboards_spec.rb
@@ -109,4 +109,64 @@ RSpec.describe "Learning teacher dashboards", type: :request do
     expect(response).to have_http_status(:ok)
     expect(response.body).not_to include("他顧問のコメント")
   end
+
+  it "差し戻し履歴がない場合に空状態UIを表示すること" do
+    get learning_teacher_dashboard_path
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include("指導改善ヒント")
+    expect(response.body).to include("まだ差し戻し履歴はありません")
+  end
+
+  it "差し戻し履歴がある場合に分析UIを表示すること" do
+    student = create(:learning_student, customer: teacher)
+    master = create(:learning_training_master,
+                    customer: teacher,
+                    title: "メトロノーム練習",
+                    judge_type: "teacher")
+    training = create(:learning_student_training,
+                      customer: teacher,
+                      learning_student: student,
+                      learning_training_master: master,
+                      title: nil)
+    assignment = training.learning_assignments.first
+    assignment.review_histories.create!(action: "revision_requested",
+                                        reviewer: teacher,
+                                        comment: "テンポを意識してみよう")
+
+    get learning_teacher_dashboard_path
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include("指導改善ヒント")
+    expect(response.body).to include("重点フォロー候補のトレーニング")
+    expect(response.body).to include("メトロノーム練習")
+    expect(response.body).to include("重点フォロー候補の生徒")
+    expect(response.body).to include(student.display_name)
+    expect(response.body).to include("最近の差し戻しコメント")
+    expect(response.body).to include("テンポを意識してみよう")
+  end
+
+  it "他顧問の差し戻し分析は表示されないこと" do
+    other_teacher2 = create(:customer, domain_name: "learning", confirmed_at: Time.current)
+    other_student2 = create(:learning_student, customer: other_teacher2)
+    other_master2 = create(:learning_training_master, customer: other_teacher2,
+                                                       title: "他顧問のトレーニング",
+                                                       judge_type: "teacher")
+    other_training2 = create(:learning_student_training,
+                              customer: other_teacher2,
+                              learning_student: other_student2,
+                              learning_training_master: other_master2,
+                              title: nil)
+    other_assignment2 = other_training2.learning_assignments.first
+    other_assignment2.review_histories.create!(action: "revision_requested",
+                                               reviewer: other_teacher2,
+                                               comment: "他顧問のコメント分析")
+
+    get learning_teacher_dashboard_path
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).not_to include("他顧問のトレーニング")
+    expect(response.body).not_to include("他顧問のコメント分析")
+    expect(response.body).to include("まだ差し戻し履歴はありません")
+  end
 end

--- a/spec/services/learning/revision_analysis_report_spec.rb
+++ b/spec/services/learning/revision_analysis_report_spec.rb
@@ -1,0 +1,236 @@
+require "rails_helper"
+
+RSpec.describe Learning::RevisionAnalysisReport do
+  let!(:learning_domain) { Domain.find_or_create_by!(name: "learning") }
+  let(:teacher) { create(:customer, domain_name: "learning", confirmed_at: Time.current) }
+  let(:other_teacher) { create(:customer, domain_name: "learning", confirmed_at: Time.current) }
+  let(:student_a) { create(:learning_student, customer: teacher, name: "生徒A") }
+  let(:student_b) { create(:learning_student, customer: teacher, name: "生徒B") }
+  let(:other_student) { create(:learning_student, customer: other_teacher, name: "他校生徒") }
+
+  subject(:report) { described_class.new(teacher) }
+
+  def create_revision_history(assignment:, comment: "テンポを確認してみよう", created_at: Time.current)
+    assignment.review_histories.create!(
+      action: "revision_requested",
+      reviewer: teacher,
+      comment: comment,
+      created_at: created_at
+    )
+  end
+
+  def create_training_assignment(student:, training_title: "コード練習")
+    master = create(:learning_training_master, customer: teacher, judge_type: "teacher",
+                                               title: training_title)
+    training = create(:learning_student_training, customer: teacher,
+                                                  learning_student: student,
+                                                  learning_training_master: master,
+                                                  title: nil)
+    training.learning_assignments.first
+  end
+
+  describe "#any_data?" do
+    it "差し戻し履歴がない場合はfalseを返すこと" do
+      expect(report.any_data?).to be false
+    end
+
+    it "差し戻し履歴がある場合はtrueを返すこと" do
+      assignment = create_training_assignment(student: student_a)
+      create_revision_history(assignment: assignment)
+
+      expect(report.any_data?).to be true
+    end
+
+    it "他顧問の差し戻し履歴はカウントしないこと" do
+      other_assignment = create(:learning_assignment, customer: other_teacher,
+                                                      learning_student: other_student)
+      create_revision_history(assignment: other_assignment)
+
+      expect(report.any_data?).to be false
+    end
+  end
+
+  describe "#troubled_trainings" do
+    it "差し戻し回数の多いトレーニングを降順で返すこと" do
+      assignment_hard = create_training_assignment(student: student_a, training_title: "難しいトレーニング")
+      assignment_easy = create_training_assignment(student: student_a, training_title: "簡単なトレーニング")
+      3.times { create_revision_history(assignment: assignment_hard) }
+      1.times { create_revision_history(assignment: assignment_easy) }
+
+      result = report.troubled_trainings
+      expect(result.first.training_title).to eq("難しいトレーニング")
+      expect(result.first.revision_count).to eq(3)
+      expect(result.second.training_title).to eq("簡単なトレーニング")
+      expect(result.second.revision_count).to eq(1)
+    end
+
+    it "同じマスターを持つ複数生徒の対象生徒数を正しく集計すること" do
+      master = create(:learning_training_master, customer: teacher, title: "コード練習",
+                                                 judge_type: "teacher")
+      training_a = create(:learning_student_training, customer: teacher,
+                                                      learning_student: student_a,
+                                                      learning_training_master: master,
+                                                      title: nil)
+      training_b = create(:learning_student_training, customer: teacher,
+                                                      learning_student: student_b,
+                                                      learning_training_master: master,
+                                                      title: nil)
+      create_revision_history(assignment: training_a.learning_assignments.first)
+      create_revision_history(assignment: training_b.learning_assignments.first)
+
+      result = report.troubled_trainings
+      expect(result.first.student_count).to eq(2)
+    end
+
+    it "最大5件を返すこと" do
+      6.times do |i|
+        assignment = create_training_assignment(student: student_a, training_title: "トレーニング#{i}")
+        create_revision_history(assignment: assignment)
+      end
+
+      expect(report.troubled_trainings.size).to be <= 5
+    end
+
+    it "他顧問のデータを含めないこと" do
+      other_assignment = create(:learning_assignment, customer: other_teacher,
+                                                      learning_student: other_student)
+      create_revision_history(assignment: other_assignment)
+
+      expect(report.troubled_trainings).to be_empty
+    end
+
+    it "改善ヒントを含むこと" do
+      assignment = create_training_assignment(student: student_a)
+      create_revision_history(assignment: assignment)
+
+      expect(report.troubled_trainings.first.improvement_hint).to eq(Learning::RevisionAnalysisReport::IMPROVEMENT_HINT)
+    end
+
+    it "トレーニング紐付きでない課題は除外すること" do
+      plain_assignment = create(:learning_assignment, customer: teacher, learning_student: student_a)
+      create_revision_history(assignment: plain_assignment)
+
+      expect(report.troubled_trainings).to be_empty
+    end
+
+    it "最新コメントを含むこと" do
+      assignment = create_training_assignment(student: student_a)
+      create_revision_history(assignment: assignment, comment: "テンポを確認してみよう",
+                              created_at: 2.hours.ago)
+      create_revision_history(assignment: assignment, comment: "音量も意識してみよう",
+                              created_at: 1.hour.ago)
+
+      expect(report.troubled_trainings.first.latest_comment).to eq("音量も意識してみよう")
+    end
+  end
+
+  describe "#struggling_students" do
+    it "差し戻し回数の多い生徒を降順で返すこと" do
+      assignment_a1 = create_training_assignment(student: student_a)
+      assignment_a2 = create_training_assignment(student: student_a, training_title: "別の練習")
+      assignment_b = create_training_assignment(student: student_b)
+      3.times { create_revision_history(assignment: assignment_a1) }
+      create_revision_history(assignment: assignment_a2)
+      create_revision_history(assignment: assignment_b)
+
+      result = report.struggling_students
+      expect(result.first.student.name).to eq("生徒A")
+      expect(result.first.revision_count).to eq(4)
+      expect(result.second.student.name).to eq("生徒B")
+      expect(result.second.revision_count).to eq(1)
+    end
+
+    it "対象トレーニング数を正しく集計すること" do
+      assignment_1 = create_training_assignment(student: student_a, training_title: "練習1")
+      assignment_2 = create_training_assignment(student: student_a, training_title: "練習2")
+      create_revision_history(assignment: assignment_1)
+      create_revision_history(assignment: assignment_2)
+
+      result = report.struggling_students
+      expect(result.first.training_count).to eq(2)
+    end
+
+    it "最大5件を返すこと" do
+      6.times do |i|
+        student = create(:learning_student, customer: teacher, name: "生徒#{i}")
+        assignment = create_training_assignment(student: student)
+        create_revision_history(assignment: assignment)
+      end
+
+      expect(report.struggling_students.size).to be <= 5
+    end
+
+    it "他顧問のデータを含めないこと" do
+      other_assignment = create(:learning_assignment, customer: other_teacher,
+                                                      learning_student: other_student)
+      create_revision_history(assignment: other_assignment)
+
+      expect(report.struggling_students).to be_empty
+    end
+
+    it "フォロー提案を含むこと" do
+      assignment = create_training_assignment(student: student_a)
+      create_revision_history(assignment: assignment)
+
+      expect(report.struggling_students.first.followup_hint).to eq(Learning::RevisionAnalysisReport::FOLLOWUP_HINT)
+    end
+
+    it "最終差し戻し日時を正しく返すこと" do
+      assignment = create_training_assignment(student: student_a)
+      create_revision_history(assignment: assignment, created_at: 3.days.ago)
+      latest = create_revision_history(assignment: assignment, created_at: 1.day.ago)
+
+      result = report.struggling_students.first
+      expect(result.last_revised_at.to_i).to eq(latest.created_at.to_i)
+    end
+  end
+
+  describe "#recent_revisions" do
+    it "コメント付き差し戻しを新しい順で返すこと" do
+      assignment = create_training_assignment(student: student_a)
+      old_rev = create_revision_history(assignment: assignment, comment: "古いコメント",
+                                        created_at: 2.days.ago)
+      new_rev = create_revision_history(assignment: assignment, comment: "新しいコメント",
+                                        created_at: 1.day.ago)
+
+      result = report.recent_revisions
+      expect(result.first.history).to eq(new_rev)
+      expect(result.second.history).to eq(old_rev)
+    end
+
+    it "コメントなしの差し戻しは除外すること" do
+      assignment = create_training_assignment(student: student_a)
+      create_revision_history(assignment: assignment, comment: nil)
+      with_comment = create_revision_history(assignment: assignment, comment: "コメントあり")
+
+      result = report.recent_revisions
+      expect(result.size).to eq(1)
+      expect(result.first.history).to eq(with_comment)
+    end
+
+    it "最大10件を返すこと" do
+      assignment = create_training_assignment(student: student_a)
+      12.times { create_revision_history(assignment: assignment, comment: "コメント") }
+
+      expect(report.recent_revisions.size).to be <= 10
+    end
+
+    it "他顧問のデータを含めないこと" do
+      other_assignment = create(:learning_assignment, customer: other_teacher,
+                                                      learning_student: other_student)
+      create_revision_history(assignment: other_assignment, comment: "他顧問のコメント")
+
+      expect(report.recent_revisions).to be_empty
+    end
+
+    it "student・training_title・assignmentを正しく返すこと" do
+      assignment = create_training_assignment(student: student_a, training_title: "8分音符練習")
+      create_revision_history(assignment: assignment, comment: "リズムを確認してみよう")
+
+      result = report.recent_revisions.first
+      expect(result.student).to eq(student_a)
+      expect(result.training_title).to eq("8分音符練習")
+      expect(result.assignment).to eq(assignment)
+    end
+  end
+end


### PR DESCRIPTION
- Learning::RevisionAnalysisReport サービスを新規追加
  - troubled_trainings: 差し戻し回数が多いトレーニングを上位5件集計 (learning_training_master_id 単位でグループし複数生徒の合算集計)
  - struggling_students: 差し戻し回数が多い生徒を上位5件集計
  - recent_revisions: コメント付き差し戻し履歴を新しい順で最大10件返す
- 顧問ダッシュボード下部に「指導改善ヒント」セクションを追加
  - 重点フォロー候補のトレーニング一覧（差し戻し回数・対象生徒・コメント・改善ヒント）
  - 重点フォロー候補の生徒一覧（差し戻し回数・対象トレーニング・最終日時・フォロー提案）
  - 最近の差し戻しコメント一覧（生徒名・トレーニング名・コメント・課題詳細リンク）
  - 差し戻し履歴がない場合は空状態UIを表示
- current_customer 経由でのみ集計し他顧問データを完全に排除
- N+1 防止: includes(learning_assignment: [:learning_student, ...]) で一括プリロード
- 建設的な文言（「つまずきやすいトレーニング」「重点フォロー候補」）を採用