### PR TITLE
feat: Singer Rank（XP・レベルシステム）を実装

### DIFF
--- a/app/assets/stylesheets/singing/users.scss
+++ b/app/assets/stylesheets/singing/users.scss
@@ -65,3 +65,247 @@
     margin-left: 0;
   }
 }
+
+// Singer Rank カード（プロフィールページ）
+$rank-colors: (
+  "singer-rank--rookie":   (#f0f9ff, #bae6fd, #0369a1),
+  "singer-rank--beginner": (#f0fdf4, #bbf7d0, #15803d),
+  "singer-rank--rising":   (#eff6ff, #bfdbfe, #1d4ed8),
+  "singer-rank--solid":    (#faf5ff, #e9d5ff, #7e22ce),
+  "singer-rank--skilled":  (#fff7ed, #fed7aa, #c2410c),
+  "singer-rank--stage":    (#fdf4ff, #f0abfc, #a21caf),
+  "singer-rank--elite":    (#fefce8, #fef08a, #a16207),
+  "singer-rank--legend":   (#fff1f2, #fecdd3, #be123c)
+);
+
+.singer-rank {
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 14px;
+  margin: 4px 0 14px;
+  padding: 12px 14px;
+
+  @each $class, $colors in $rank-colors {
+    &.#{$class} {
+      background: linear-gradient(135deg, nth($colors, 1), lighten(nth($colors, 2), 8%));
+      border-color: nth($colors, 2);
+
+      .singer-rank__label { color: nth($colors, 3); }
+      .singer-rank__level { color: nth($colors, 3); opacity: 0.75; }
+      .singer-rank__xp    { color: nth($colors, 3); }
+      .singer-rank__progress-fill { background: nth($colors, 3); }
+      .singer-rank__progress-label { color: nth($colors, 3); opacity: 0.8; }
+      .singer-rank__max { color: nth($colors, 3); }
+    }
+  }
+}
+
+.singer-rank__header {
+  align-items: center;
+  display: flex;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.singer-rank__icon {
+  flex-shrink: 0;
+  font-size: 22px;
+  line-height: 1;
+}
+
+.singer-rank__info {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+}
+
+.singer-rank__label {
+  font-size: 14px;
+  font-weight: 700;
+  line-height: 1.3;
+}
+
+.singer-rank__level {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+}
+
+.singer-rank__xp {
+  font-size: 12px;
+  font-weight: 700;
+  margin-left: auto;
+  white-space: nowrap;
+}
+
+.singer-rank__progress {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.singer-rank__progress-bar {
+  background: rgba(0, 0, 0, 0.1);
+  border-radius: 99px;
+  height: 6px;
+  overflow: hidden;
+  width: 100%;
+}
+
+.singer-rank__progress-fill {
+  border-radius: 99px;
+  height: 100%;
+  transition: width 0.4s ease;
+}
+
+.singer-rank__progress-label {
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.singer-rank__max {
+  font-size: 12px;
+  font-weight: 700;
+  text-align: center;
+}
+
+// Singer Rank 結果通知（診断結果ページ）
+.singer-rank-result {
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 14px;
+  margin: 0 0 20px;
+  padding: 14px 16px;
+
+  @each $class, $colors in $rank-colors {
+    &.#{$class} {
+      background: linear-gradient(135deg, nth($colors, 1), lighten(nth($colors, 2), 8%));
+      border-color: nth($colors, 2);
+
+      .singer-rank-result__xp-value   { color: nth($colors, 3); }
+      .singer-rank-result__xp-label   { color: nth($colors, 3); }
+      .singer-rank-result__rank-label { color: nth($colors, 3); }
+      .singer-rank-result__rank-level { color: nth($colors, 3); opacity: 0.75; }
+      .singer-rank-result__progress-fill { background: nth($colors, 3); }
+      .singer-rank-result__progress-label { color: nth($colors, 3); opacity: 0.8; }
+      .singer-rank-result__profile-link { color: nth($colors, 3); }
+    }
+  }
+}
+
+.singer-rank-result__xp-gained {
+  align-items: center;
+  display: flex;
+  gap: 6px;
+  margin-bottom: 10px;
+}
+
+.singer-rank-result__xp-icon {
+  font-size: 20px;
+  line-height: 1;
+}
+
+.singer-rank-result__xp-value {
+  font-size: 22px;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+}
+
+.singer-rank-result__xp-label {
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.singer-rank-result__rank {
+  align-items: center;
+  display: flex;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+
+.singer-rank-result__rank-icon {
+  flex-shrink: 0;
+  font-size: 22px;
+  line-height: 1;
+}
+
+.singer-rank-result__rank-body {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.singer-rank-result__rank-label {
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.singer-rank-result__rank-level {
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.singer-rank-result__progress {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-bottom: 10px;
+}
+
+.singer-rank-result__progress-bar {
+  background: rgba(0, 0, 0, 0.1);
+  border-radius: 99px;
+  height: 6px;
+  overflow: hidden;
+  width: 100%;
+}
+
+.singer-rank-result__progress-fill {
+  border-radius: 99px;
+  height: 100%;
+  transition: width 0.4s ease;
+}
+
+.singer-rank-result__progress-label {
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.singer-rank-result__profile-link {
+  display: inline-block;
+  font-size: 12px;
+  font-weight: 700;
+  text-decoration: none;
+
+  &:hover { text-decoration: underline; }
+}
+
+// シェアカードのランクバッジ
+.singing-share-image__singer-rank {
+  align-items: center;
+  background: rgba(0, 0, 0, 0.06);
+  border-radius: 8px;
+  display: flex;
+  gap: 6px;
+  margin: 12px 0 0;
+  padding: 8px 12px;
+}
+
+.singing-share-image__singer-rank-icon {
+  font-size: 18px;
+  line-height: 1;
+}
+
+.singing-share-image__singer-rank-label {
+  color: #1f2937;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.singing-share-image__singer-rank-level {
+  color: #4b5563;
+  font-size: 11px;
+  font-weight: 600;
+  margin-left: auto;
+}

--- a/app/controllers/singing/diagnoses_controller.rb
+++ b/app/controllers/singing/diagnoses_controller.rb
@@ -68,6 +68,11 @@ class Singing::DiagnosesController < Singing::BaseController
         @ranking_top10_threshold = top10_score_threshold
       end
       @next_badges = Singing::NextBadgeService.call(current_customer)
+      @singer_rank = current_customer.singer_rank
+      @singer_rank_progress = current_customer.singer_rank_progress
+      @singer_next_rank = current_customer.singer_next_rank
+      xp_gained = (50 + (@diagnosis.overall_score.to_f / 100 * 50).round).to_i
+      @xp_gained = xp_gained
     end
   end
 

--- a/app/controllers/singing/share_images_controller.rb
+++ b/app/controllers/singing/share_images_controller.rb
@@ -4,6 +4,7 @@ class Singing::ShareImagesController < Singing::BaseController
   def show
     @share_image = Singing::YearlyGrowthShareImageBuilder.call(current_customer)
     redirect_to singing_diagnoses_path, alert: "今年の診断がまだないため、シェアカードは表示できません。" unless @share_image.present?
+    @singer_rank = current_customer.singer_rank
   end
 
   private

--- a/app/controllers/singing/users_controller.rb
+++ b/app/controllers/singing/users_controller.rb
@@ -18,6 +18,9 @@ class Singing::UsersController < Singing::BaseController
                           .includes(:singing_ranking_season)
                           .order(awarded_at: :desc)
     @profile_title = Singing::ProfileTitleService.call(@season_badges)
+    @singer_rank = @user.singer_rank
+    @singer_rank_progress = @user.singer_rank_progress
+    @singer_next_rank = @user.singer_next_rank
     @ranking_badges = Singing::RankingBadgeService.badges_for(@user)
     @next_badges = current_customer == @user ? Singing::NextBadgeService.call(@user) : []
     @growth_entries = Singing::RankingQuery.growth

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -240,6 +240,18 @@ class Customer < ApplicationRecord
     monthly_singing_diagnosis_count(reference_time) < limit
   end
 
+  def singer_rank
+    Singing::SingerRankService.rank_for(singing_xp)
+  end
+
+  def singer_rank_progress
+    Singing::SingerRankService.xp_progress(singing_xp)
+  end
+
+  def singer_next_rank
+    Singing::SingerRankService.next_rank_for(singing_xp)
+  end
+
   def has_feature?(feature_key)
     return true if admin?
 

--- a/app/services/singing/singer_rank_service.rb
+++ b/app/services/singing/singer_rank_service.rb
@@ -1,0 +1,63 @@
+module Singing
+  class SingerRankService
+    Rank = Struct.new(:level, :label, :icon, :color_class, :min_xp, keyword_init: true)
+
+    RANKS = [
+      { level: 1, label: "見習いシンガー",     icon: "🎵", color_class: "singer-rank--rookie",   min_xp: 0    },
+      { level: 2, label: "駆け出しシンガー",   icon: "🌱", color_class: "singer-rank--beginner", min_xp: 100  },
+      { level: 3, label: "上昇気流",           icon: "🌊", color_class: "singer-rank--rising",   min_xp: 300  },
+      { level: 4, label: "本格派",             icon: "⭐", color_class: "singer-rank--solid",    min_xp: 600  },
+      { level: 5, label: "実力派",             icon: "🌟", color_class: "singer-rank--skilled",  min_xp: 1000 },
+      { level: 6, label: "ステージの申し子",   icon: "🎤", color_class: "singer-rank--stage",    min_xp: 1500 },
+      { level: 7, label: "一流シンガー",       icon: "💫", color_class: "singer-rank--elite",    min_xp: 2500 },
+      { level: 8, label: "レジェンドシンガー", icon: "👑", color_class: "singer-rank--legend",   min_xp: 4000 }
+    ].map { |attrs| Rank.new(**attrs) }.freeze
+
+    MAX_LEVEL = RANKS.last.level
+
+    def self.rank_for(xp)
+      new(xp).rank_for
+    end
+
+    def self.next_rank_for(xp)
+      new(xp).next_rank
+    end
+
+    def self.xp_progress(xp)
+      new(xp).xp_progress
+    end
+
+    def self.level_for_xp(xp)
+      rank_for(xp).level
+    end
+
+    def initialize(xp)
+      @xp = xp.to_i
+    end
+
+    def rank_for
+      RANKS.reverse.find { |rank| @xp >= rank.min_xp } || RANKS.first
+    end
+
+    def next_rank
+      current_level = rank_for.level
+      return nil if current_level >= MAX_LEVEL
+
+      RANKS.find { |rank| rank.level == current_level + 1 }
+    end
+
+    def xp_progress
+      current = rank_for
+      nxt = next_rank
+
+      return { percent: 100, xp_in_tier: 0, xp_for_tier: 0, xp_to_next: 0 } if nxt.nil?
+
+      xp_in_tier   = @xp - current.min_xp
+      xp_for_tier  = nxt.min_xp - current.min_xp
+      xp_to_next   = nxt.min_xp - @xp
+      percent       = (xp_in_tier.to_f / xp_for_tier * 100).round.clamp(0, 100)
+
+      { percent: percent, xp_in_tier: xp_in_tier, xp_for_tier: xp_for_tier, xp_to_next: xp_to_next }
+    end
+  end
+end

--- a/app/services/singing/xp_granter.rb
+++ b/app/services/singing/xp_granter.rb
@@ -1,0 +1,46 @@
+module Singing
+  class XpGranter
+    BASE_XP = 50
+    SCORE_BONUS_MAX = 50
+
+    Result = Struct.new(:xp_gained, :leveled_up, :old_rank, :new_rank, :new_xp, keyword_init: true)
+
+    def self.call(diagnosis)
+      new(diagnosis).call
+    end
+
+    def initialize(diagnosis)
+      @diagnosis = diagnosis
+      @customer  = diagnosis.customer
+    end
+
+    def call
+      return nil unless @customer && @diagnosis.completed?
+
+      xp_gained  = calculate_xp
+      old_xp     = @customer.singing_xp
+      old_rank   = SingerRankService.rank_for(old_xp)
+      new_xp     = old_xp + xp_gained
+      new_rank   = SingerRankService.rank_for(new_xp)
+      leveled_up = new_rank.level > old_rank.level
+      new_level  = new_rank.level
+
+      @customer.update_columns(singing_xp: new_xp, singing_level: new_level)
+
+      Result.new(
+        xp_gained:  xp_gained,
+        leveled_up: leveled_up,
+        old_rank:   old_rank,
+        new_rank:   new_rank,
+        new_xp:     new_xp
+      )
+    end
+
+    private
+
+    def calculate_xp
+      score_bonus = ((@diagnosis.overall_score.to_f / 100) * SCORE_BONUS_MAX).round
+      BASE_XP + score_bonus
+    end
+  end
+end

--- a/app/services/singing_diagnoses/result_persister.rb
+++ b/app/services/singing_diagnoses/result_persister.rb
@@ -26,6 +26,7 @@ module SingingDiagnoses
       )
 
       enqueue_ai_comment_if_available
+      grant_xp
 
       true
     rescue StandardError => e
@@ -49,6 +50,12 @@ module SingingDiagnoses
 
     def score_payload
       @score_payload ||= payload[:common] || payload["common"] || payload
+    end
+
+    def grant_xp
+      Singing::XpGranter.call(diagnosis)
+    rescue StandardError => e
+      Rails.logger.error("XpGranter failed for diagnosis #{diagnosis.id}: #{e.message}")
     end
 
     def enqueue_ai_comment_if_available

--- a/app/views/singing/diagnoses/show.html.haml
+++ b/app/views/singing/diagnoses/show.html.haml
@@ -118,6 +118,26 @@
                   %span.singing-diagnosis__season-badge-new NEW
           = link_to "すべてのバッジを見る →", singing_badges_path, class: "singing-diagnosis__badges-link"
 
+      - if @singer_rank
+        .singer-rank-result{ class: @singer_rank.color_class }
+          .singer-rank-result__xp-gained
+            %span.singer-rank-result__xp-icon ⚡
+            %strong.singer-rank-result__xp-value= "+#{@xp_gained} XP"
+            %span.singer-rank-result__xp-label 獲得！
+          .singer-rank-result__rank
+            %span.singer-rank-result__rank-icon= @singer_rank.icon
+            .singer-rank-result__rank-body
+              %strong.singer-rank-result__rank-label= @singer_rank.label
+              %span.singer-rank-result__rank-level= "Lv.#{@singer_rank.level}  |  通算 #{current_customer.singing_xp} XP"
+          - if @singer_next_rank
+            - progress = @singer_rank_progress
+            .singer-rank-result__progress
+              .singer-rank-result__progress-bar
+                .singer-rank-result__progress-fill{ style: "width: #{progress[:percent]}%" }
+              %span.singer-rank-result__progress-label= "次のランク「#{@singer_next_rank.icon} #{@singer_next_rank.label}」まで #{progress[:xp_to_next]} XP"
+          = link_to singing_user_path(current_customer), class: "singer-rank-result__profile-link" do
+            自分のランクページを見る →
+
       - if @next_badges.present?
         .singing-diagnosis__next-badges
           .singing-diagnosis__next-badges-header

--- a/app/views/singing/share_images/show.html.haml
+++ b/app/views/singing/share_images/show.html.haml
@@ -48,6 +48,11 @@
             %strong= @share_image.song_label
             %small most sung
 
+        .singing-share-image__singer-rank
+          %span.singing-share-image__singer-rank-icon= @singer_rank.icon
+          %span.singing-share-image__singer-rank-label= @singer_rank.label
+          %span.singing-share-image__singer-rank-level= "Lv.#{@singer_rank.level}"
+
         .singing-share-image__footer
           %span= @share_image.hashtag
           %small Screenshot ready

--- a/app/views/singing/users/show.html.haml
+++ b/app/views/singing/users/show.html.haml
@@ -13,6 +13,24 @@
             %strong.singing-profile__title-label= @profile_title.label
             %span.singing-profile__title-desc= @profile_title.description
           = link_to "バッジ一覧 →", singing_badges_path, class: "singing-profile__title-link"
+
+        - progress = @singer_rank_progress
+        .singer-rank{ class: @singer_rank.color_class }
+          .singer-rank__header
+            %span.singer-rank__icon= @singer_rank.icon
+            .singer-rank__info
+              %strong.singer-rank__label= @singer_rank.label
+              %span.singer-rank__level= "Lv.#{@singer_rank.level}"
+            %span.singer-rank__xp= "#{@user.singing_xp} XP"
+          - if @singer_next_rank
+            .singer-rank__progress
+              .singer-rank__progress-bar
+                .singer-rank__progress-fill{ style: "width: #{progress[:percent]}%" }
+              %span.singer-rank__progress-label= "次のランクまで #{progress[:xp_to_next]} XP"
+          - else
+            .singer-rank__max
+              %span MAX RANK 達成！
+
         - if @user.singing_profile_comment.present?
           %p.singing-profile__comment= @user.singing_profile_comment
         - else

--- a/db/migrate/20260514141733_add_singer_rank_to_customers.rb
+++ b/db/migrate/20260514141733_add_singer_rank_to_customers.rb
@@ -1,0 +1,6 @@
+class AddSingerRankToCustomers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :customers, :singing_xp, :integer, default: 0, null: false
+    add_column :customers, :singing_level, :integer, default: 1, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2026_05_13_001000) do
+ActiveRecord::Schema.define(version: 2026_05_14_141733) do
 
   create_table "active_admin_comments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "namespace"
@@ -293,6 +293,8 @@ ActiveRecord::Schema.define(version: 2026_05_13_001000) do
     t.text "achievements"
     t.boolean "onboarding_done"
     t.string "singing_profile_comment", limit: 120
+    t.integer "singing_xp", default: 0, null: false
+    t.integer "singing_level", default: 1, null: false
     t.index ["email"], name: "index_customers_on_email", unique: true
     t.index ["reset_password_token"], name: "index_customers_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
診断を重ねるほどXPが溜まりランクアップするゲーミフィケーション機能。
- customers に singing_xp / singing_level カラムを追加
- Lv1〜8のランク定義（見習いシンガー → レジェンドシンガー）
- 診断完了後にベースXP50 + スコアボーナス最大50を自動付与
- プロフィール・診断結果・シェアカードにランク表示を追加