### PR TITLE
feat: デイリーチャレンジ機能を実装

### DIFF
--- a/app/assets/stylesheets/singing/diagnoses.scss
+++ b/app/assets/stylesheets/singing/diagnoses.scss
@@ -8343,3 +8343,182 @@ $ranking-accent: #7c4dff;
   background: #9a5800;
   color: #fff;
 }
+
+// ========================================
+// デイリーチャレンジ バナー（診断フォームページ）
+// ========================================
+.daily-challenge-banner {
+  background: linear-gradient(135deg, #eff6ff, #dbeafe);
+  border: 1px solid #93c5fd;
+  border-radius: 14px;
+  margin-bottom: 24px;
+  padding: 14px 16px;
+
+  &.daily-challenge-banner--done {
+    background: linear-gradient(135deg, #f0fdf4, #dcfce7);
+    border-color: #86efac;
+  }
+}
+
+.daily-challenge-banner__header {
+  align-items: center;
+  display: flex;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+
+.daily-challenge-banner__date-label {
+  color: #1d4ed8;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+
+  .daily-challenge-banner--done & { color: #15803d; }
+}
+
+.daily-challenge-banner__xp-badge {
+  background: #1d4ed8;
+  border-radius: 99px;
+  color: #fff;
+  font-size: 11px;
+  font-weight: 800;
+  margin-left: auto;
+  padding: 2px 10px;
+}
+
+.daily-challenge-banner__done-badge {
+  background: #15803d;
+  border-radius: 99px;
+  color: #fff;
+  font-size: 11px;
+  font-weight: 700;
+  margin-left: auto;
+  padding: 2px 10px;
+}
+
+.daily-challenge-banner__body {
+  align-items: flex-start;
+  display: flex;
+  gap: 10px;
+}
+
+.daily-challenge-banner__icon {
+  flex-shrink: 0;
+  font-size: 24px;
+  line-height: 1;
+}
+
+.daily-challenge-banner__text {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.daily-challenge-banner__title {
+  color: #1e3a5f;
+  font-size: 15px;
+  font-weight: 700;
+
+  .daily-challenge-banner--done & { color: #14532d; }
+}
+
+.daily-challenge-banner__desc {
+  color: #3b5ea6;
+  font-size: 13px;
+
+  .daily-challenge-banner--done & { color: #166534; }
+}
+
+// ========================================
+// デイリーチャレンジ 結果カード（診断結果ページ）
+// ========================================
+.daily-challenge-result {
+  background: linear-gradient(135deg, #eff6ff, #dbeafe);
+  border: 1px solid #93c5fd;
+  border-radius: 14px;
+  margin-bottom: 20px;
+  padding: 14px 16px;
+
+  &.daily-challenge-result--cleared {
+    background: linear-gradient(135deg, #f0fdf4, #dcfce7);
+    border-color: #86efac;
+  }
+}
+
+.daily-challenge-result__header {
+  align-items: center;
+  display: flex;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+
+.daily-challenge-result__date-label {
+  color: #1d4ed8;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+
+  .daily-challenge-result--cleared & { color: #15803d; }
+}
+
+.daily-challenge-result__xp-badge {
+  background: #1d4ed8;
+  border-radius: 99px;
+  color: #fff;
+  font-size: 11px;
+  font-weight: 800;
+  margin-left: auto;
+  padding: 2px 10px;
+}
+
+.daily-challenge-result__cleared-badge {
+  background: #15803d;
+  border-radius: 99px;
+  color: #fff;
+  font-size: 11px;
+  font-weight: 700;
+  margin-left: auto;
+  padding: 2px 10px;
+}
+
+.daily-challenge-result__body {
+  align-items: flex-start;
+  display: flex;
+  gap: 10px;
+  margin-bottom: 8px;
+}
+
+.daily-challenge-result__icon {
+  flex-shrink: 0;
+  font-size: 24px;
+  line-height: 1;
+}
+
+.daily-challenge-result__text {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.daily-challenge-result__title {
+  color: #1e3a5f;
+  font-size: 15px;
+  font-weight: 700;
+
+  .daily-challenge-result--cleared & { color: #14532d; }
+}
+
+.daily-challenge-result__desc {
+  color: #3b5ea6;
+  font-size: 13px;
+
+  .daily-challenge-result--cleared & { color: #166534; }
+}
+
+.daily-challenge-result__hint {
+  color: #4b5563;
+  font-size: 12px;
+  margin: 0;
+}

--- a/app/controllers/singing/diagnoses_controller.rb
+++ b/app/controllers/singing/diagnoses_controller.rb
@@ -17,6 +17,8 @@ class Singing::DiagnosesController < Singing::BaseController
 
   def new
     @diagnosis = current_customer.singing_diagnoses.build
+    @daily_challenge = Singing::DailyChallengeGenerator.ensure_today
+    @daily_challenge_progress = @daily_challenge.progress_for(current_customer)
   end
 
   def create
@@ -68,6 +70,8 @@ class Singing::DiagnosesController < Singing::BaseController
         @ranking_top10_threshold = top10_score_threshold
       end
       @next_badges = Singing::NextBadgeService.call(current_customer)
+      @daily_challenge = Singing::DailyChallengeGenerator.ensure_today
+      @daily_challenge_progress = @daily_challenge.progress_for(current_customer)
     end
   end
 

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -130,6 +130,7 @@ class Customer < ApplicationRecord
   has_many :singing_diagnoses, dependent: :destroy
   has_many :singing_ai_challenge_progresses, dependent: :destroy
   has_many :singing_badges, dependent: :destroy
+  has_many :singing_daily_challenge_progresses, dependent: :destroy
   has_many :singing_profile_reactions, dependent: :destroy
   has_many :received_singing_profile_reactions,
            class_name: "SingingProfileReaction",

--- a/app/models/singing_daily_challenge.rb
+++ b/app/models/singing_daily_challenge.rb
@@ -1,0 +1,50 @@
+class SingingDailyChallenge < ApplicationRecord
+  CHALLENGE_TYPES = %w[score_threshold count].freeze
+  TARGET_ATTRIBUTES = %w[overall pitch rhythm expression].freeze
+
+  has_many :singing_daily_challenge_progresses, dependent: :destroy
+
+  validates :challenge_date, presence: true, uniqueness: true
+  validates :challenge_type, presence: true, inclusion: { in: CHALLENGE_TYPES }
+  validates :target_attribute, presence: true, inclusion: { in: TARGET_ATTRIBUTES }
+  validates :threshold_value, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+  validates :xp_reward, presence: true, numericality: { only_integer: true, greater_than: 0 }
+  validates :title, presence: true
+  validates :description, presence: true
+
+  scope :for_date, ->(date) { find_by(challenge_date: date) }
+
+  TARGET_ATTRIBUTE_LABELS = {
+    "overall"    => "総合スコア",
+    "pitch"      => "ピッチ",
+    "rhythm"     => "リズム",
+    "expression" => "表現力"
+  }.freeze
+
+  TARGET_ATTRIBUTE_ICONS = {
+    "overall"    => "🎯",
+    "pitch"      => "🎵",
+    "rhythm"     => "🥁",
+    "expression" => "✨"
+  }.freeze
+
+  def target_label
+    TARGET_ATTRIBUTE_LABELS.fetch(target_attribute, target_attribute)
+  end
+
+  def target_icon
+    TARGET_ATTRIBUTE_ICONS.fetch(target_attribute, "🎯")
+  end
+
+  def score_column
+    "#{target_attribute}_score"
+  end
+
+  def completed_by?(customer)
+    singing_daily_challenge_progresses.exists?(customer: customer, singing_daily_challenge: self)
+  end
+
+  def progress_for(customer)
+    singing_daily_challenge_progresses.find_by(customer: customer)
+  end
+end

--- a/app/models/singing_daily_challenge_progress.rb
+++ b/app/models/singing_daily_challenge_progress.rb
@@ -1,0 +1,10 @@
+class SingingDailyChallengeProgress < ApplicationRecord
+  belongs_to :customer
+  belongs_to :singing_daily_challenge
+
+  validates :customer_id, uniqueness: { scope: :singing_daily_challenge_id }
+
+  def completed?
+    completed_at.present?
+  end
+end

--- a/app/services/singing/daily_challenge_evaluator.rb
+++ b/app/services/singing/daily_challenge_evaluator.rb
@@ -1,0 +1,61 @@
+module Singing
+  class DailyChallengeEvaluator
+    Result = Struct.new(:completed, :xp_awarded, :challenge, keyword_init: true)
+
+    def self.call(diagnosis)
+      new(diagnosis).call
+    end
+
+    def initialize(diagnosis)
+      @diagnosis = diagnosis
+      @customer  = diagnosis.customer
+    end
+
+    def call
+      return nil unless @diagnosis.completed? && @customer
+
+      challenge = Singing::DailyChallengeGenerator.ensure_today
+      return nil if challenge.completed_by?(@customer)
+
+      return nil unless meets_challenge?(challenge)
+
+      award!(challenge)
+    end
+
+    private
+
+    def meets_challenge?(challenge)
+      case challenge.challenge_type
+      when "score_threshold"
+        score = @diagnosis.public_send(challenge.score_column)
+        score.present? && score >= challenge.threshold_value
+      when "count"
+        today_count = @customer.singing_diagnoses
+          .completed
+          .where(created_at: Date.current.all_day)
+          .count
+        today_count >= challenge.threshold_value
+      else
+        false
+      end
+    end
+
+    def award!(challenge)
+      progress = SingingDailyChallengeProgress.create!(
+        customer:                 @customer,
+        singing_daily_challenge:  challenge,
+        completed_at:             Time.current,
+        xp_rewarded:              challenge.xp_reward
+      )
+
+      @customer.update_columns(
+        singing_xp:    @customer.singing_xp + challenge.xp_reward,
+        singing_level: Singing::SingerRankService.level_for_xp(@customer.singing_xp + challenge.xp_reward)
+      )
+
+      Result.new(completed: true, xp_awarded: challenge.xp_reward, challenge: challenge)
+    rescue ActiveRecord::RecordNotUnique
+      nil
+    end
+  end
+end

--- a/app/services/singing/daily_challenge_generator.rb
+++ b/app/services/singing/daily_challenge_generator.rb
@@ -1,0 +1,35 @@
+module Singing
+  class DailyChallengeGenerator
+    CHALLENGE_POOL = [
+      { challenge_type: "score_threshold", target_attribute: "overall",    threshold_value: 70,  xp_reward: 30, title: "今日は総合70点を目指せ！",   description: "総合スコア70点以上を1回達成しよう。" },
+      { challenge_type: "score_threshold", target_attribute: "overall",    threshold_value: 80,  xp_reward: 40, title: "今日は総合80点チャレンジ！", description: "総合スコア80点以上を1回達成しよう。" },
+      { challenge_type: "score_threshold", target_attribute: "pitch",      threshold_value: 75,  xp_reward: 30, title: "ピッチ精度75点に挑戦！",     description: "ピッチスコア75点以上を1回達成しよう。" },
+      { challenge_type: "score_threshold", target_attribute: "pitch",      threshold_value: 85,  xp_reward: 40, title: "ピッチマスターを目指せ！",   description: "ピッチスコア85点以上を1回達成しよう。" },
+      { challenge_type: "score_threshold", target_attribute: "rhythm",     threshold_value: 75,  xp_reward: 30, title: "リズム感75点チャレンジ！",   description: "リズムスコア75点以上を1回達成しよう。" },
+      { challenge_type: "score_threshold", target_attribute: "rhythm",     threshold_value: 85,  xp_reward: 40, title: "リズムマスターに挑戦！",     description: "リズムスコア85点以上を1回達成しよう。" },
+      { challenge_type: "score_threshold", target_attribute: "expression", threshold_value: 70,  xp_reward: 30, title: "表現力70点チャレンジ！",     description: "表現力スコア70点以上を1回達成しよう。" },
+      { challenge_type: "score_threshold", target_attribute: "expression", threshold_value: 80,  xp_reward: 40, title: "表現力の達人を目指せ！",     description: "表現力スコア80点以上を1回達成しよう。" },
+      { challenge_type: "count",           target_attribute: "overall",    threshold_value: 1,   xp_reward: 20, title: "今日1回診断してみよう！",     description: "1回でも診断を完了させよう。まずは記録から！" },
+      { challenge_type: "count",           target_attribute: "overall",    threshold_value: 2,   xp_reward: 35, title: "今日2回チャレンジ！",         description: "今日2回診断を完了させよう。練習の積み重ねが大事！" },
+    ].freeze
+
+    def self.ensure_today
+      new.ensure_today
+    end
+
+    def ensure_today
+      date = Date.current
+      SingingDailyChallenge.find_or_create_by!(challenge_date: date) do |challenge|
+        template = pick_template(date)
+        challenge.assign_attributes(template)
+      end
+    end
+
+    private
+
+    def pick_template(date)
+      index = date.to_time.to_i % CHALLENGE_POOL.size
+      CHALLENGE_POOL[index]
+    end
+  end
+end

--- a/app/services/singing_diagnoses/result_persister.rb
+++ b/app/services/singing_diagnoses/result_persister.rb
@@ -26,6 +26,8 @@ module SingingDiagnoses
       )
 
       enqueue_ai_comment_if_available
+      grant_xp
+      evaluate_daily_challenge
 
       true
     rescue StandardError => e
@@ -49,6 +51,18 @@ module SingingDiagnoses
 
     def score_payload
       @score_payload ||= payload[:common] || payload["common"] || payload
+    end
+
+    def grant_xp
+      Singing::XpGranter.call(diagnosis)
+    rescue StandardError => e
+      Rails.logger.error("XpGranter failed for diagnosis #{diagnosis.id}: #{e.message}")
+    end
+
+    def evaluate_daily_challenge
+      Singing::DailyChallengeEvaluator.call(diagnosis)
+    rescue StandardError => e
+      Rails.logger.error("DailyChallengeEvaluator failed for diagnosis #{diagnosis.id}: #{e.message}")
     end
 
     def enqueue_ai_comment_if_available

--- a/app/views/singing/diagnoses/new.html.haml
+++ b/app/views/singing/diagnoses/new.html.haml
@@ -4,6 +4,20 @@
     %h1 歌唱・演奏診断を依頼する
     %p 音声ファイルを添付して、診断リクエストを作成します。
 
+    - if @daily_challenge
+      .daily-challenge-banner{ class: (@daily_challenge_progress&.completed? ? "daily-challenge-banner--done" : "") }
+        .daily-challenge-banner__header
+          %span.daily-challenge-banner__date-label= "TODAY'S CHALLENGE #{Date.current.strftime('%m/%d')}"
+          - if @daily_challenge_progress&.completed?
+            %span.daily-challenge-banner__done-badge ✅ クリア済み
+          - else
+            %span.daily-challenge-banner__xp-badge= "+#{@daily_challenge.xp_reward} XP"
+        .daily-challenge-banner__body
+          %span.daily-challenge-banner__icon= @daily_challenge.target_icon
+          .daily-challenge-banner__text
+            %strong.daily-challenge-banner__title= @daily_challenge.title
+            %span.daily-challenge-banner__desc= @daily_challenge.description
+
     .singing-diagnosis__quota{ class: ("singing-diagnosis__quota--limited" if @singing_diagnosis_quota_exceeded) }
       - if @singing_diagnosis_quota_limited
         %h2 今月の歌唱・演奏診断

--- a/app/views/singing/diagnoses/show.html.haml
+++ b/app/views/singing/diagnoses/show.html.haml
@@ -85,6 +85,22 @@
               %small= card[:short_label]
               %p= card[:comment]
 
+      - if @daily_challenge
+        .daily-challenge-result{ class: (@daily_challenge_progress&.completed? ? "daily-challenge-result--cleared" : "") }
+          .daily-challenge-result__header
+            %span.daily-challenge-result__date-label= "TODAY'S CHALLENGE #{Date.current.strftime('%m/%d')}"
+            - if @daily_challenge_progress&.completed?
+              %span.daily-challenge-result__cleared-badge ✅ クリア！ +#{@daily_challenge_progress.xp_rewarded} XP
+            - else
+              %span.daily-challenge-result__xp-badge= "+#{@daily_challenge.xp_reward} XP"
+          .daily-challenge-result__body
+            %span.daily-challenge-result__icon= @daily_challenge.target_icon
+            .daily-challenge-result__text
+              %strong.daily-challenge-result__title= @daily_challenge.title
+              %span.daily-challenge-result__desc= @daily_challenge.description
+          - unless @daily_challenge_progress&.completed?
+            %p.daily-challenge-result__hint 条件を満たしていれば自動でクリア判定されます。未達成の場合は再挑戦しよう！
+
       - if @new_season_badges.present?
         .singing-diagnosis__badge-celebration
           .singing-diagnosis__badge-celebration-header

--- a/db/migrate/20260514142554_create_singing_daily_challenges.rb
+++ b/db/migrate/20260514142554_create_singing_daily_challenges.rb
@@ -1,0 +1,17 @@
+class CreateSingingDailyChallenges < ActiveRecord::Migration[6.1]
+  def change
+    create_table :singing_daily_challenges do |t|
+      t.date :challenge_date, null: false
+      t.string :challenge_type, null: false
+      t.string :target_attribute, null: false
+      t.integer :threshold_value, null: false
+      t.integer :xp_reward, null: false, default: 30
+      t.string :title, null: false
+      t.text :description, null: false
+
+      t.timestamps
+    end
+
+    add_index :singing_daily_challenges, :challenge_date, unique: true
+  end
+end

--- a/db/migrate/20260514142555_create_singing_daily_challenge_progresses.rb
+++ b/db/migrate/20260514142555_create_singing_daily_challenge_progresses.rb
@@ -1,0 +1,19 @@
+class CreateSingingDailyChallengeProgresses < ActiveRecord::Migration[6.1]
+  def change
+    create_table :singing_daily_challenge_progresses do |t|
+      t.references :customer, null: false, foreign_key: true, index: false
+      t.bigint :singing_daily_challenge_id, null: false
+      t.datetime :completed_at
+      t.integer :xp_rewarded, default: 0, null: false
+
+      t.timestamps
+    end
+
+    add_foreign_key :singing_daily_challenge_progresses, :singing_daily_challenges,
+                    name: "fk_sdcp_on_singing_daily_challenge"
+    add_index :singing_daily_challenge_progresses,
+              [:customer_id, :singing_daily_challenge_id],
+              unique: true,
+              name: "idx_sdcp_customer_challenge"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2026_05_13_001000) do
+ActiveRecord::Schema.define(version: 2026_05_14_142555) do
 
   create_table "active_admin_comments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "namespace"
@@ -293,6 +293,8 @@ ActiveRecord::Schema.define(version: 2026_05_13_001000) do
     t.text "achievements"
     t.boolean "onboarding_done"
     t.string "singing_profile_comment", limit: 120
+    t.integer "singing_xp", default: 0, null: false
+    t.integer "singing_level", default: 1, null: false
     t.index ["email"], name: "index_customers_on_email", unique: true
     t.index ["reset_password_token"], name: "index_customers_on_reset_password_token", unique: true
   end
@@ -850,6 +852,30 @@ ActiveRecord::Schema.define(version: 2026_05_13_001000) do
     t.index ["singing_ranking_season_id"], name: "index_singing_badges_on_season_id"
   end
 
+  create_table "singing_daily_challenge_progresses", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "customer_id", null: false
+    t.bigint "singing_daily_challenge_id", null: false
+    t.datetime "completed_at"
+    t.integer "xp_rewarded", default: 0, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["customer_id", "singing_daily_challenge_id"], name: "idx_sdcp_customer_challenge", unique: true
+    t.index ["singing_daily_challenge_id"], name: "fk_sdcp_on_singing_daily_challenge"
+  end
+
+  create_table "singing_daily_challenges", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.date "challenge_date", null: false
+    t.string "challenge_type", null: false
+    t.string "target_attribute", null: false
+    t.integer "threshold_value", null: false
+    t.integer "xp_reward", default: 30, null: false
+    t.string "title", null: false
+    t.text "description", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["challenge_date"], name: "index_singing_daily_challenges_on_challenge_date", unique: true
+  end
+
   create_table "singing_diagnoses", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "customer_id", null: false
     t.string "song_title"
@@ -1077,6 +1103,8 @@ ActiveRecord::Schema.define(version: 2026_05_13_001000) do
   add_foreign_key "singing_ai_challenge_progresses", "customers"
   add_foreign_key "singing_badges", "customers"
   add_foreign_key "singing_badges", "singing_ranking_seasons"
+  add_foreign_key "singing_daily_challenge_progresses", "customers"
+  add_foreign_key "singing_daily_challenge_progresses", "singing_daily_challenges", name: "fk_sdcp_on_singing_daily_challenge"
   add_foreign_key "singing_diagnoses", "customers"
   add_foreign_key "singing_profile_reactions", "customers"
   add_foreign_key "singing_profile_reactions", "customers", column: "target_customer_id"


### PR DESCRIPTION
毎日0時に「今日のチャレンジ」が切り替わるゲーミフィケーション機能。
- SingingDailyChallenge / SingingDailyChallengeProgress テーブルを追加
- 10種類のチャレンジプールから日付ベースで毎日自動生成
- 診断完了後に条件を自動判定しXPを付与（ResultPersisterにフック追加）
- 診断フォームページにチャレンジバナーを表示
- 診断結果ページにクリア状態付きのチャレンジカードを表示