### PR TITLE
feat: Recap Movie Placeholder UX Polish

### DIFF
--- a/app/assets/javascripts/singing/recap_movie_request.js
+++ b/app/assets/javascripts/singing/recap_movie_request.js
@@ -10,16 +10,17 @@ document.addEventListener("turbolinks:load", () => {
   let pollTimer = null;
 
   const el = {
-    intro:       document.getElementById("rmp-intro"),
-    generateBtn: document.getElementById("rmp-generate-btn"),
-    retryBtn:    document.getElementById("rmp-retry-btn"),
-    statusArea:  document.getElementById("rmp-status-area"),
-    statusMsg:   document.getElementById("rmp-status-msg"),
-    spinner:     document.getElementById("rmp-spinner"),
-    videoArea:   document.getElementById("rmp-video-area"),
-    videoLink:   document.getElementById("rmp-video-link"),
-    retryArea:   document.getElementById("rmp-retry-area"),
-    emptyMsg:    document.getElementById("rmp-empty-msg"),
+    intro:           document.getElementById("rmp-intro"),
+    generateBtn:     document.getElementById("rmp-generate-btn"),
+    retryBtn:        document.getElementById("rmp-retry-btn"),
+    statusArea:      document.getElementById("rmp-status-area"),
+    statusMsg:       document.getElementById("rmp-status-msg"),
+    spinner:         document.getElementById("rmp-spinner"),
+    videoArea:       document.getElementById("rmp-video-area"),
+    videoLink:       document.getElementById("rmp-video-link"),
+    retryArea:       document.getElementById("rmp-retry-area"),
+    previewLinkArea: document.getElementById("rmp-preview-link-area"),
+    emptyMsg:        document.getElementById("rmp-empty-msg"),
   };
 
   const show = (e) => e && (e.style.display = "");
@@ -32,6 +33,7 @@ document.addEventListener("turbolinks:load", () => {
     hide(el.statusArea);
     hide(el.videoArea);
     hide(el.retryArea);
+    hide(el.previewLinkArea);
     hide(el.emptyMsg);
 
     switch (state) {
@@ -52,6 +54,12 @@ document.addEventListener("turbolinks:load", () => {
           show(el.videoArea);
           if (el.videoLink) el.videoLink.href = data.videoUrl;
         }
+        break;
+      case "renderer_preparing":
+        show(el.statusArea);
+        hide(el.spinner);
+        if (el.statusMsg) el.statusMsg.textContent = "動画生成機能は現在準備中です。まずはストーリーボードPreviewをお楽しみください。";
+        show(el.previewLinkArea);
         break;
       case "failed":
         show(el.statusArea);
@@ -84,7 +92,11 @@ document.addEventListener("turbolinks:load", () => {
           setState("completed", { videoUrl: data.movie && data.movie.video_url });
         } else if (data.status === "failed" || data.status === "expired") {
           stopPolling();
-          setState("failed");
+          if (data.movie && data.movie.renderer_preparing) {
+            setState("renderer_preparing");
+          } else {
+            setState("failed");
+          }
         }
         // pending / processing: 引き続き polling、表示はそのまま
       })
@@ -134,6 +146,8 @@ document.addEventListener("turbolinks:load", () => {
       } else if (data.status === "pending" || data.status === "processing") {
         setState("loading");
         startPolling();
+      } else if (data.status === "failed" && data.movie && data.movie.renderer_preparing) {
+        setState("renderer_preparing");
       } else {
         setState("idle");
       }

--- a/app/assets/stylesheets/singing/recap_movie_preview.scss
+++ b/app/assets/stylesheets/singing/recap_movie_preview.scss
@@ -347,44 +347,58 @@
 .rmp-scene--aurora     { border-left: 4px solid #22d3ee; }
 .rmp-scene--dark_stage { border-left: 4px solid #fbbf24; }
 
-// ── Remotion 接続ヒント ──────────────────────────────────────────────────────
+// ── Coming Soon バッジ ────────────────────────────────────────────────────────
 
-.rmp-export-hint {
+.rmp-coming-soon-badge {
+  align-items: center;
+  background: rgba(251, 191, 36, 0.1);
+  border: 1px solid rgba(251, 191, 36, 0.3);
+  border-radius: 999px;
+  color: #fbbf24;
+  display: inline-flex;
+  flex-wrap: wrap;
+  font-size: 0.82rem;
+  font-weight: 700;
+  gap: 6px;
+  margin-bottom: 24px;
+  padding: 7px 14px;
+}
+
+.rmp-coming-soon-badge__sep {
+  color: rgba(251, 191, 36, 0.4);
+}
+
+// ── Coming Soon パネル（export hint 代替） ───────────────────────────────────
+
+.rmp-coming-soon-panel {
   align-items: flex-start;
-  background: rgba(79, 70, 229, 0.08);
-  border: 1px solid rgba(79, 70, 229, 0.2);
+  background: rgba(251, 191, 36, 0.06);
+  border: 1px solid rgba(251, 191, 36, 0.2);
   border-radius: 14px;
   display: flex;
   gap: 14px;
   margin-bottom: 32px;
-  padding: 20px 20px;
+  padding: 20px;
 }
 
-.rmp-export-hint__icon {
+.rmp-coming-soon-panel__icon {
   flex-shrink: 0;
   font-size: 1.5rem;
   line-height: 1;
 }
 
-.rmp-export-hint__title {
-  color: #a5b4fc;
+.rmp-coming-soon-panel__title {
+  color: #fbbf24;
   font-size: 0.88rem;
   font-weight: 800;
   margin: 0 0 5px;
 }
 
-.rmp-export-hint__desc {
+.rmp-coming-soon-panel__desc {
   color: #8b949e;
   font-size: 0.85rem;
   line-height: 1.6;
   margin: 0;
-
-  code {
-    background: rgba(255, 255, 255, 0.08);
-    border-radius: 4px;
-    font-size: 0.82em;
-    padding: 1px 5px;
-  }
 }
 
 // ── 生成セクション ────────────────────────────────────────────────────────────
@@ -468,6 +482,10 @@
 }
 
 .rmp-generate__retry {
+  margin-top: 16px;
+}
+
+.rmp-generate__preview-link {
   margin-top: 16px;
 }
 

--- a/app/controllers/singing/badges_controller.rb
+++ b/app/controllers/singing/badges_controller.rb
@@ -42,6 +42,9 @@ class Singing::BadgesController < Singing::BaseController
     "expired"       => "Recap Movieの有効期限が切れています。"
   }.freeze
 
+  RENDERER_NOT_IMPLEMENTED_ERROR = "Renderer is not implemented."
+  RENDERER_PREPARING_MESSAGE     = "動画生成機能は現在準備中です。"
+
   def timeline
     @timeline_groups = Singing::AchievementTimelineBuilder.call(current_customer)
     @can_share_achievement = current_customer.has_feature?(:singing_achievement_badge_share_image)
@@ -91,11 +94,17 @@ class Singing::BadgesController < Singing::BaseController
       return
     end
 
+    status_message = if renderer_preparing?(movie)
+      RENDERER_PREPARING_MESSAGE
+    else
+      RECAP_MOVIE_STATUS_MESSAGES[movie.status] || movie.status
+    end
+
     render json: {
       exists:  true,
       year:    year,
       status:  movie.status,
-      message: RECAP_MOVIE_STATUS_MESSAGES[movie.status] || movie.status,
+      message: status_message,
       movie:   movie_status_payload(movie)
     }
   end
@@ -234,16 +243,22 @@ class Singing::BadgesController < Singing::BaseController
   end
 
   def movie_status_payload(movie)
+    preparing = renderer_preparing?(movie)
     {
-      id:            movie.id,
-      year:          movie.year,
-      status:        movie.status,
-      reusable:      movie.reusable?,
-      video_url:     recap_movie_video_url(movie),
-      error_message: movie.error_message,
-      generated_at:  movie.generated_at,
-      expires_at:    movie.expires_at
+      id:                 movie.id,
+      year:               movie.year,
+      status:             movie.status,
+      reusable:           movie.reusable?,
+      video_url:          recap_movie_video_url(movie),
+      error_message:      preparing ? nil : movie.error_message,
+      renderer_preparing: preparing,
+      generated_at:       movie.generated_at,
+      expires_at:         movie.expires_at
     }
+  end
+
+  def renderer_preparing?(movie)
+    movie.failed? && movie.error_message == RENDERER_NOT_IMPLEMENTED_ERROR
   end
 
   def recap_movie_video_url(movie)

--- a/app/views/singing/badges/recap_movie_preview.html.haml
+++ b/app/views/singing/badges/recap_movie_preview.html.haml
@@ -34,7 +34,12 @@
             %span.rmp-header__meta-icon ⏱
             = "総尺 #{@recap.total_duration}秒"
 
-      .rmp-storyboard{ role: "list", "aria-label" => "映画シーン一覧" }
+      .rmp-coming-soon-badge
+        🎞️ Movie生成は準備中
+        %span.rmp-coming-soon-badge__sep ·
+        現在はストーリーボードPreviewとして確認できます
+
+      .rmp-storyboard#rmp-storyboard{ role: "list", "aria-label" => "映画シーン一覧" }
         - @recap.scenes.each do |scene|
           .rmp-scene{ class: ["rmp-scene--#{scene.background_style}", "rmp-scene--emotion-#{scene.emotion}"],
                       role: "listitem",
@@ -74,9 +79,9 @@
         %noscript.rmp-generate__noscript
           Recap Movieを生成するには JavaScript を有効にしてください。
         .rmp-generate__intro#rmp-intro
-          あなたの一年を映画のように振り返る準備ができます。
+          現在、動画生成機能は準備中です。まずは絵コンテPreviewをお楽しみください。
         %button.rmp-btn.rmp-btn--generate#rmp-generate-btn{ type: "button" }
-          🎬 Recap Movieを生成する
+          🎬 Recap Movieを生成する（試験的）
         .rmp-generate__status#rmp-status-area{ style: "display:none" }
           .rmp-generate__spinner#rmp-spinner{ "aria-hidden" => "true" }
           %p.rmp-generate__status-msg#rmp-status-msg
@@ -86,17 +91,18 @@
         .rmp-generate__retry#rmp-retry-area{ style: "display:none" }
           %button.rmp-btn.rmp-btn--secondary#rmp-retry-btn{ type: "button" }
             もう一度試す
+        .rmp-generate__preview-link#rmp-preview-link-area{ style: "display:none" }
+          %a.rmp-btn.rmp-btn--secondary{ href: "#rmp-storyboard" }
+            🎞️ Previewを見る
         %p.rmp-generate__empty-msg#rmp-empty-msg{ style: "display:none" }
           今年のAchievementがまだありません。
 
-      .rmp-export-hint
-        .rmp-export-hint__icon 🚀
-        .rmp-export-hint__body
-          %p.rmp-export-hint__title 将来の Remotion 接続ポイント
-          %p.rmp-export-hint__desc
-            このシーン構成は
-            %code /singing/recap_movies/:year
-            経由で Remotion に渡せる JSON として出力できます。
+      .rmp-coming-soon-panel
+        .rmp-coming-soon-panel__icon 🎞️
+        .rmp-coming-soon-panel__body
+          %p.rmp-coming-soon-panel__title Movie生成は準備中
+          %p.rmp-coming-soon-panel__desc
+            現在はストーリーボードPreviewとして確認できます。動画生成機能は今後リリース予定です。
 
       .rmp-actions
         = link_to yearly_rewind_singing_badges_path(year: @year), class: "rmp-btn rmp-btn--secondary" do

--- a/spec/requests/singing/badges_spec.rb
+++ b/spec/requests/singing/badges_spec.rb
@@ -1300,6 +1300,48 @@ RSpec.describe "Singing::Badges", type: :request do
           expect(json[:movie][:error_message]).to be_present
           expect(json[:movie][:reusable]).to be false
         end
+
+        it "通常の failed は renderer_preparing が false であること" do
+          get recap_movie_status_singing_badges_path, params: { year: year }, as: :json
+
+          json = JSON.parse(response.body, symbolize_names: true)
+          expect(json[:movie][:renderer_preparing]).to be false
+        end
+      end
+
+      context "failed かつ Renderer is not implemented. の場合" do
+        let!(:movie) do
+          create(:singing_generated_recap_movie, :failed, customer: customer, year: year,
+                 error_message: "Renderer is not implemented.")
+        end
+
+        it "message が技術文言を含まないこと" do
+          get recap_movie_status_singing_badges_path, params: { year: year }, as: :json
+
+          json = JSON.parse(response.body, symbolize_names: true)
+          expect(json[:message]).not_to include("Renderer is not implemented.")
+        end
+
+        it "message が準備中文言を含むこと" do
+          get recap_movie_status_singing_badges_path, params: { year: year }, as: :json
+
+          json = JSON.parse(response.body, symbolize_names: true)
+          expect(json[:message]).to include("準備中")
+        end
+
+        it "movie.renderer_preparing が true であること" do
+          get recap_movie_status_singing_badges_path, params: { year: year }, as: :json
+
+          json = JSON.parse(response.body, symbolize_names: true)
+          expect(json[:movie][:renderer_preparing]).to be true
+        end
+
+        it "movie.error_message が nil であること（技術文言を隠す）" do
+          get recap_movie_status_singing_badges_path, params: { year: year }, as: :json
+
+          json = JSON.parse(response.body, symbolize_names: true)
+          expect(json[:movie][:error_message]).to be_nil
+        end
       end
 
       context "expired の場合" do


### PR DESCRIPTION
- failed + "Renderer is not implemented." の場合、APIレスポンスの message を準備中文言に変換し、技術エラー文を隠す
- movie_status_payload に renderer_preparing フラグを追加、error_message は nil でマスク
- Preview UI に coming soon badge / panel を追加（🎞️ Movie生成は準備中）
- generate セクションの CTA 文言を準備中向けに調整
- JS: renderer_preparing 状態を追加し「もう一度試す」→「Previewを見る」に切り替え
- RSpec: renderer not implemented の場合の message / renderer_preparing / error_message をテスト