### PR TITLE
fix: 新EC2のpuma socketパス・許可ホストを反映する

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -2,8 +2,10 @@ require "active_support/core_ext/integer/time"
 
 Rails.application.configure do
   config.hosts << "be-my-style.com"
-  config.hosts << "www.be-my-style.com" 
-  
+  config.hosts << "www.be-my-style.com"
+  config.hosts << "16.76.125.187"
+  config.hosts << "127.0.0.1"
+
   # Settings specified here will take precedence over those in config/application.rb.
 
   # Code is not reloaded between requests.

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -25,14 +25,14 @@ else
   tmp_dir = "#{app_dir}/tmp"
   log_dir = "#{app_dir}/log"
 
-  bind "unix://#{tmp_dir}/sockets/puma.sock"
+  bind "unix:///run/puma/puma.sock"
   pidfile "#{tmp_dir}/pids/puma.pid"
   state_path "#{tmp_dir}/pids/puma.state"
 
   stdout_redirect "#{log_dir}/puma.stdout.log", "#{log_dir}/puma.stderr.log", true
 
   # pumactlを使う場合はこちら（任意）
-  activate_control_app "unix://#{tmp_dir}/sockets/pumactl.sock"
+  activate_control_app "unix:///run/puma/pumactl.sock"
 end
 
 # プロセスフォーク前後のDB接続管理


### PR DESCRIPTION
## Summary
- 新EC2でのpuma socket path修正。次回デプロイ時にnginx↔puma疎通が壊れるリスクを防ぐための対応です。
- 昨日実施したEC2リプレイス後、新サーバー上で `config/puma.rb` と `config/environments/production.rb` に未コミットの手動修正が入っていることを確認した。
  - `config/puma.rb`: bind先を `tmp/sockets/puma.sock` → `/run/puma/puma.sock` に変更（nginxの upstream 設定も `/run/puma/puma.sock` を参照済み。systemd unitの `RuntimeDirectory=puma` に対応するための変更）。
  - `config/environments/production.rb`: `config.hosts` に新EC2向けの許可IP（`16.76.125.187`, `127.0.0.1`）を追加。
- CI/CDは `git fetch && git reset --hard origin/main` を実行するため、この変更をmainに取り込まないと、次回デプロイでサーバー上の手動修正が上書きされ、nginx↔puma疎通が壊れる恐れがあった。

## Test plan
- [x] `git diff --check`
- [x] `DISABLE_SPRING=1 bundle exec rails runner 'puts "boot ok"'`
- [x] 新EC2で読み取り専用SSH確認により、変更内容が現行の手動修正と一致することを確認済み
- [x] 新EC2にswap 1GB追加済み（assets:precompile時のOOM対策、既存プロセスは無変更）
- [ ] マージ後、GitHub ActionsのCI/CDが新EC2へ正常にデプロイできることを確認
- [ ] デプロイ後、`sudo systemctl status puma` / `curl -I https://be-my-style.com` 等でサイト正常性を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)