### PR TITLE
feat: 管理コミュニティ権限でCoreプラン未満でもイベント作成できるようにする

### DIFF
--- a/app/controllers/public/events_controller.rb
+++ b/app/controllers/public/events_controller.rb
@@ -333,7 +333,7 @@ class Public::EventsController < ApplicationController
 
     if community_param_present && community.blank?
       redirect_to public_events_path, alert: "イベントを作成するコミュニティを確認してください。"
-    elsif community&.premium_event_creation_required? && !current_customer.premium? && !current_customer.admin?
+    elsif community&.premium_event_creation_required? && !current_customer.premium? && !current_customer.admin? && !current_customer.can_manage_community?(community)
       redirect_to public_community_path(community), alert: premium_event_creation_required_message
     elsif !current_customer.can_create_event?(community)
       redirect_to public_events_path, alert: "イベントを作成する権限がありません。"

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -385,9 +385,8 @@ class Customer < ApplicationRecord
   
   def available_communities_for_event
     return Community.all if admin?
-    return Community.none unless can_create_events_by_plan?
 
-    manageable_communities.select { |community| event_creation_required_plan_met?(community) }
+    manageable_communities
   end
 
   def eligible_to_create_event_for?(community = nil)
@@ -398,8 +397,12 @@ class Customer < ApplicationRecord
     manageable_communities.exists?
   end
 
+  # 管理コミュニティ権限（admin付与のCommunityOwner）があるコミュニティは、
+  # Coreプラン以上の判定を問わずイベント作成を許可する。
   def can_create_event?(community = nil)
     return true if admin?
+    return true if community.present? && can_manage_community?(community)
+    return true if community.blank? && manageable_communities.exists?
     return false unless can_create_events_by_plan?
     return true if community.blank?
 

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -308,24 +308,24 @@ RSpec.describe 'Customerモデルのテスト', type: :model do
         expect(customer.can_create_event?(owned_community)).to eq true
       end
 
-      it 'CoreユーザーはPremium由来コミュニティのオーナーでもイベント作成できないこと' do
+      it '管理コミュニティ権限があればCoreユーザーでもPremium由来コミュニティのイベント作成できること' do
         owned_community.update!(required_plan_for_event_creation: "premium")
         customer.create_subscription!(status: "active", plan: "core")
 
-        expect(customer.can_create_event?(owned_community)).to eq false
+        expect(customer.can_create_event?(owned_community)).to eq true
       end
 
-      it 'Freeユーザーは通常コミュニティのオーナーでもイベント作成できないこと' do
-        expect(customer.can_create_event?(owned_community)).to eq false
+      it '管理コミュニティ権限があればFreeユーザーでも通常コミュニティのイベント作成できること' do
+        expect(customer.can_create_event?(owned_community)).to eq true
       end
 
-      it 'Lightユーザーは通常コミュニティのオーナーでもイベント作成できないこと' do
+      it '管理コミュニティ権限があればLightユーザーでも通常コミュニティのイベント作成できること' do
         customer.create_subscription!(status: "active", plan: "light")
 
-        expect(customer.can_create_event?(owned_community)).to eq false
+        expect(customer.can_create_event?(owned_community)).to eq true
       end
 
-      it 'オーナーでないCoreユーザーは通常コミュニティでもイベント作成できないこと' do
+      it '管理コミュニティ権限がなければCoreユーザーでも当該コミュニティのイベント作成できないこと' do
         customer.create_subscription!(status: "active", plan: "core")
         other_community = FactoryBot.create(:community, owner_id: other_customer.id)
         CommunityCustomer.find_or_create_by!(customer: customer, community: other_community)

--- a/spec/requests/public/events_spec.rb
+++ b/spec/requests/public/events_spec.rb
@@ -84,20 +84,16 @@ RSpec.describe "Public::Events", type: :request do
         CommunityCustomer.find_or_create_by!(customer: customer, community: premium_origin_community)
       end
 
-      it "Coreユーザーはnewでブロックされ、Premium案内が表示されること" do
+      it "管理コミュニティ権限があればCoreユーザーでもPremium由来コミュニティで作成ページを表示できること" do
         get new_public_event_path(community_id: premium_origin_community.id)
 
-        expect(response).to redirect_to(public_community_path(premium_origin_community))
-        follow_redirect!
-        expect(response.body).to include("Premiumプランが必要です")
+        expect(response.status).to eq 200
       end
 
-      it "Coreユーザーはcreateでブロックされ、イベントが作成されないこと" do
+      it "管理コミュニティ権限があればCoreユーザーでもPremium由来コミュニティでイベントを作成できること" do
         expect do
           post public_events_path, params: event_create_params(premium_origin_community)
-        end.not_to change(Event, :count)
-
-        expect(response).to redirect_to(public_community_path(premium_origin_community))
+        end.to change(Event, :count).by(1)
       end
 
       it "PremiumユーザーはPremium由来コミュニティで作成ページを表示できること" do
@@ -106,6 +102,30 @@ RSpec.describe "Public::Events", type: :request do
         get new_public_event_path(community_id: premium_origin_community.id)
 
         expect(response.status).to eq 200
+      end
+
+      context "管理コミュニティ権限のないユーザーの場合" do
+        let(:unmanaged_premium_community) { FactoryBot.create(:community, :premium_origin, owner_id: other_customer.id) }
+
+        before do
+          CommunityCustomer.find_or_create_by!(customer: customer, community: unmanaged_premium_community)
+        end
+
+        it "Coreユーザーはnewでブロックされ、Premium案内が表示されること" do
+          get new_public_event_path(community_id: unmanaged_premium_community.id)
+
+          expect(response).to redirect_to(public_community_path(unmanaged_premium_community))
+          follow_redirect!
+          expect(response.body).to include("Premiumプランが必要です")
+        end
+
+        it "Coreユーザーはcreateでブロックされ、イベントが作成されないこと" do
+          expect do
+            post public_events_path, params: event_create_params(unmanaged_premium_community)
+          end.not_to change(Event, :count)
+
+          expect(response).to redirect_to(public_community_path(unmanaged_premium_community))
+        end
       end
     end
     context "event編集ページ(edit)が正しく表示される" do
@@ -258,7 +278,7 @@ RSpec.describe "Public::Events", type: :request do
         songs_attributes: {
           "0" => {
             song_name: "Session Song",
-            performance_time: "5",
+            performance_time: "5:00",
             join_parts_attributes: {
               "0" => { join_part_name: "Vocal" }
             }


### PR DESCRIPTION
## Summary
- 管理画面の「管理コミュニティ」(Customer ⇔ Community の中間テーブル `community_owners`、`owned_community_ids` で保存)でチェックが入っているコミュニティについて、Coreプラン未満のユーザーでもイベント作成できるようにした。
- 既存の「Coreプラン以上ならイベント作成可能」というロジックは維持し、「管理コミュニティ権限があるコミュニティなら作成可能」をOR条件として追加している(`can_create_project_for?` と同じ設計パターン)。
- `Customer#can_create_event?` に、対象コミュニティを管理している場合(`can_manage_community?`)の早期returnを追加。
- `Customer#available_communities_for_event` は管理コミュニティをプランでフィルタせずそのまま返すよう変更(イベント作成モーダル・フォームのコミュニティ選択肢に反映)。
- `Public::EventsController#authorize_event_creation!` のPremium限定コミュニティガードにも、管理コミュニティ権限によるバイパスを追加(controller側でも権限チェックを維持、view表示だけに依存しない)。

### 挙動まとめ
- Coreプラン以上のユーザー: 従来通り作成可能(無変更)
- 管理コミュニティ権限を持つユーザー: プラン・コミュニティ個別のPremium限定設定を問わず作成可能(新規、完全バイパス)
- どちらも満たさないユーザー: 従来通りブロック

### 挙動変更に関する注記
- 「管理コミュニティ権限」はコミュニティ個別のPremium限定要件(`required_plan_for_event_creation: premium`)も含めて完全にバイパスする仕様として実装している(要件確認済み)。
- これに伴い、既存の `spec/models/customer_spec.rb` と `spec/requests/public/events_spec.rb` のうち、「管理コミュニティ権限があってもプラン不足ならブロックされる」という旧仕様を検証していたテストケースを、新仕様(管理コミュニティ権限があればプラン不問で作成可能)に合わせて更新した。管理コミュニティ権限を持たないユーザーが依然としてブロックされることを検証するテストは新規追加している。

## Test plan
- [x] `git diff --check`
- [x] `DISABLE_SPRING=1 bundle exec rails runner 'puts "boot ok"'`
- [x] `bundle exec rspec spec/models/customer_spec.rb spec/requests/public/events_spec.rb` (既存の無関係な失敗2件を除き成功)
- [ ] マージ後、CI/CDで正常にデプロイされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)