### PR TITLE
Allow free plan users to use community chat

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,10 +8,10 @@ class ApplicationController < ActionController::Base
       upgrade_path: -> { public_lp_path(anchor: "lp-section") }
     },
     music_community_chat: {
-      required_plan: "light",
+      required_plan: "free",
       title: "コミュニティチャット",
-      message: "lightプラン以上でコミュニティチャットに参加できます。メンバー同士の会話をもっと深めたい方におすすめです。",
-      cta: "lightでチャットを開放",
+      message: "コミュニティチャットはfreeプランから閲覧・投稿できます。",
+      cta: "チャットを始める",
       upgrade_path: -> { public_lp_path(anchor: "lp-section") }
     },
     music_activity_create: {

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -19,7 +19,7 @@ class Customer < ApplicationRecord
 
   FEATURE_RULES = {
     music_direct_chat: %w[free light core premium],
-    music_community_chat: %w[light core premium],
+    music_community_chat: %w[free light core premium],
     music_activity_create: %w[free light core premium],
     music_event_create: %w[core premium],
     music_community_mail: %w[premium],

--- a/app/views/public/communities/show.html.haml
+++ b/app/views/public/communities/show.html.haml
@@ -73,15 +73,8 @@
             %tr
               %th{scope:"row"} チャットする
               %td
-                - if ChatRoomCustomer.where(customer_id: current_customer.id, community_id: @community.id).present? && feature_available?(:music_community_chat)
+                - if ChatRoomCustomer.where(customer_id: current_customer.id, community_id: @community.id).present?
                   = link_to 'コミュニティのチャットルームへ', community_create_public_chat_rooms_path(community_id: @community.id), method: :post, class: "btn btn-sm btn-info community-show-btn", data: { 'turbolinks': false }
-                - elsif ChatRoomCustomer.where(customer_id: current_customer.id, community_id: @community.id).present?
-                  = render "shared/feature_gate",
-                    feature_key: :music_community_chat,
-                    title: "コミュニティチャット",
-                    message: "参加メンバーとの会話はlightプラン以上で開放できます。",
-                    cta: "lightでチャットを開放",
-                    class_name: "feature-gate--table"
                 - else
                   コミュニティに参加するとチャットできます。
             - if current_customer.communities.include?(@community) || current_customer.can_manage_community?(@community)

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -242,6 +242,20 @@ RSpec.describe 'Customerモデルのテスト', type: :model do
         expect(customer.has_feature?(:music_direct_chat)).to eq true
       end
 
+      it 'freeはコミュニティチャットの閲覧・投稿ともに利用できること' do
+        expect(customer.has_feature?(:music_community_chat)).to eq true
+      end
+
+      it 'lightもコミュニティチャットの閲覧・投稿ともに利用できること' do
+        customer.create_subscription!(status: "active", plan: "light")
+
+        expect(customer.has_feature?(:music_community_chat)).to eq true
+      end
+
+      it '他の有料限定機能(イベント作成)はfreeでは利用できないこと' do
+        expect(customer.has_feature?(:music_event_create)).to eq false
+      end
+
       it 'lightは履歴比較まで利用対象になること' do
         customer.create_subscription!(status: "active", plan: "light")
 

--- a/spec/requests/public/community_chat_plan_spec.rb
+++ b/spec/requests/public/community_chat_plan_spec.rb
@@ -1,0 +1,81 @@
+require 'rails_helper'
+
+RSpec.describe "コミュニティチャットの閲覧・投稿権限のテスト", type: :request do
+  let!(:customer) { create(:customer) }
+  let!(:owner) { create(:customer) }
+  let(:community) { create(:community, owner_id: owner.id) }
+  let(:chat_room) { create(:chat_room) }
+  let!(:owner_chat_room_customer) { create(:chat_room_customer, customer: owner, chat_room: chat_room, community: community) }
+  let!(:member_chat_room_customer) { create(:chat_room_customer, customer: customer, chat_room: chat_room, community: community) }
+
+  describe 'ログイン済み（コミュニティ参加済み）' do
+    before { sign_in customer }
+
+    context 'Freeプランの場合' do
+      it 'コミュニティ詳細ページにチャットルームへのリンクが表示されること' do
+        get public_community_path(community)
+        expect(response.body).to include('コミュニティのチャットルームへ')
+      end
+
+      it 'コミュニティチャットルームへ入室できること(community_create)' do
+        post community_create_public_chat_rooms_path(community_id: community.id)
+        expect(response).to redirect_to(community_show_public_chat_rooms_path(chat_room))
+      end
+
+      it 'コミュニティチャットルームを閲覧できること(community_show)' do
+        get community_show_public_chat_rooms_path(chat_room)
+        expect(response.status).to eq 200
+        expect(response.body).to include('コミュニティチャットルームへようこそ!')
+      end
+
+      it '通常の投稿フォームが表示されること' do
+        get community_show_public_chat_rooms_path(chat_room)
+        expect(response.body).to include('メッセージを送信')
+      end
+
+      it 'コミュニティチャットへの投稿ができること(community_create)' do
+        expect do
+          post community_create_public_chat_messages_path, params: {
+            chat_message: { content: "お元気ですか？", chat_room_id: chat_room.id }
+          }
+        end.to change(ChatMessage, :count).by(1)
+      end
+    end
+
+    context 'Lightプラン以上の場合' do
+      before { customer.create_subscription!(status: "active", plan: "light") }
+
+      it 'これまで通りコミュニティチャットルームを閲覧できること' do
+        get community_show_public_chat_rooms_path(chat_room)
+        expect(response.status).to eq 200
+      end
+
+      it 'これまで通りコミュニティチャットへ投稿できること(community_create)' do
+        expect do
+          post community_create_public_chat_messages_path, params: {
+            chat_message: { content: "お元気ですか？", chat_room_id: chat_room.id }
+          }
+        end.to change(ChatMessage, :count).by(1)
+      end
+    end
+  end
+
+  describe '未ログイン' do
+    it 'コミュニティチャットルームの閲覧はログイン画面へリダイレクトされること' do
+      get community_show_public_chat_rooms_path(chat_room)
+      expect(response).to redirect_to(new_customer_session_path)
+    end
+  end
+
+  describe '他の有料機能フラグへの影響がないこと' do
+    before { sign_in customer }
+
+    it 'イベント作成はCore未満のFreeユーザーには従来通り開放されないこと' do
+      expect(customer.has_feature?(:music_event_create)).to eq false
+    end
+
+    it 'コミュニティ作成はFreeユーザーには従来通り開放されないこと' do
+      expect(customer.has_feature?(:music_community_create)).to eq false
+    end
+  end
+end


### PR DESCRIPTION
## 変更概要
コミュニティチャットが `light` プラン以上限定になっていた問題を修正し、Freeプランでも閲覧・投稿の両方ができるようにした。

これまでは `Customer::FEATURE_RULES[:music_community_chat]` と `ApplicationController::FEATURE_CATALOG[:music_community_chat]` が `required_plan: "light"` に設定されており、`Public::ChatRoomsController#community_create`（入室）と `Public::ChatMessagesController#community_create`（投稿）の両方をこのフラグでゲートしていた。今回 `music_community_chat` の許可プランを `free light core premium` に変更し、Free含む全プランで閲覧・投稿できるようにした。

（実装過程で一時的に閲覧用/投稿用フラグを分離したが、最終的に両者の権限が完全に一致したため単一フラグ `music_community_chat` に統合している）

## 変更ファイル一覧
- `app/models/customer.rb` — `FEATURE_RULES[:music_community_chat]` に `free` を追加
- `app/controllers/application_controller.rb` — `FEATURE_CATALOG[:music_community_chat]` の `required_plan` を `free` に変更、メッセージ文言を更新
- `app/views/public/communities/show.html.haml` — チャットルームへのリンク表示条件からプラン判定を撤去（参加済みなら常に表示）
- `spec/models/customer_spec.rb` — `music_community_chat` がfree/lightともに利用可能なこと、他機能(`music_event_create`)がfreeで従来通り利用不可なことを確認するテストを追加
- `spec/requests/public/community_chat_plan_spec.rb`（新規） — 閲覧・投稿・未ログイン・他機能への影響のテストを追加

投稿・編集・削除など閲覧以外の権限、および歌唱診断・イベント作成・オーナー機能・管理機能などの他の有料制限は変更していない。

## Freeプランで閲覧・投稿できる確認結果
`spec/requests/public/community_chat_plan_spec.rb` で以下をrequest specとして確認済み:
1. Freeプランの参加済みユーザーがコミュニティ詳細ページのチャットリンクを閲覧できる
2. Freeプランの参加済みユーザーがチャットルームへ入室・メッセージ一覧を閲覧できる（200 OK）
3. Freeプランの参加済みユーザーが通常の投稿フォームを見られ、実際に投稿（ChatMessage作成）できる
4. Light以上のユーザーも従来通り閲覧・投稿できる
5. 未ログインユーザーはログイン画面へリダイレクトされる（変更なし）

## 他の有料機能に影響がないこと
- `music_event_create`（イベント作成, core以上）、`music_community_create`（コミュニティ作成, premium限定）など他の `FEATURE_RULES` エントリは無変更
- `spec/models/customer_spec.rb` と `spec/requests/public/community_chat_plan_spec.rb` で、Freeユーザーがこれら他機能を依然として利用できないことを明示的に確認済み

## RSpec結果
- `DISABLE_SPRING=1 bundle exec rails runner 'puts "boot ok"'` → OK
- `git diff --check` → 問題なし（ホワイトスペースエラー・不要ファイル混入なし）
- フルスイート: mainベースライン（4047 examples, 55 failures）に対し、本ブランチは 4060 examples（新規13件）, 55 failures。**失敗数は同一で新規のリグレッションなし**

## 既存の無関係な失敗（55件）について
mainブランチの時点で既に55件のテストが失敗しており、いずれも今回の変更とは無関係（Stripe決済画面のルーティングエラー、コミュニティ退会時の人数カウント、通知メソッドの引数不一致、`chat_room_spec.rb`/`chat_message_spec.rb`内の一部テストにおけるコミュニティメンバーシップfactory設定不備など）。今回のブランチでも同数・同内容のまま残っており、本PRのスコープ外として着手していない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)